### PR TITLE
Refactor produce and continuation handling to use references instead of owned values across multiple files

### DIFF
--- a/casper/src/rust/helper/test_result_collector.rs
+++ b/casper/src/rust/helper/test_result_collector.rs
@@ -242,8 +242,8 @@ impl TestResultCollector {
                         test_result_collector.update(new_test_result);
 
                         if let Err(e) = produce(
-                            vec![new_gbool_par(assertion.is_success(), Vec::new(), false)],
-                            ack_channel.clone(),
+                            &vec![new_gbool_par(assertion.is_success(), Vec::new(), false)],
+                            &ack_channel.clone(),
                         )
                         .await
                         {
@@ -264,8 +264,8 @@ impl TestResultCollector {
                         test_result_collector.update(new_test_result);
 
                         if let Err(e) = produce(
-                            vec![new_gbool_par(assertion.is_success(), Vec::new(), false)],
-                            ack_channel.clone(),
+                            &vec![new_gbool_par(assertion.is_success(), Vec::new(), false)],
+                            &ack_channel.clone(),
                         )
                         .await
                         {
@@ -290,8 +290,8 @@ impl TestResultCollector {
                     test_result_collector.update(new_test_result);
 
                     if let Err(e) = produce(
-                        vec![new_gbool_par(condition, Vec::new(), false)],
-                        ack_channel.clone(),
+                        &vec![new_gbool_par(condition, Vec::new(), false)],
+                        &ack_channel.clone(),
                     )
                     .await
                     {
@@ -312,8 +312,8 @@ impl TestResultCollector {
                     test_result_collector.update(new_test_result);
 
                     if let Err(e) = produce(
-                        vec![new_gbool_par(false, Vec::new(), false)],
-                        ack_channel.clone(),
+                        &vec![new_gbool_par(false, Vec::new(), false)],
+                        &ack_channel.clone(),
                     )
                     .await
                     {

--- a/rholang/tests/reduce_spec.rs
+++ b/rholang/tests/reduce_spec.rs
@@ -100,8 +100,8 @@ fn check_continuation(
             data: Vec::new(),
             wks: vec![WaitingContinuation::create(
                 &channels,
-                bind_patterns,
-                TaggedContinuation {
+                &bind_patterns,
+                &TaggedContinuation {
                     tagged_cont: Some(TaggedCont::ParBody(body)),
                 },
                 false,

--- a/rspace++/libs/rspace_rhotypes/src/lib.rs
+++ b/rspace++/libs/rspace_rhotypes/src/lib.rs
@@ -585,7 +585,7 @@ pub extern "C" fn reset_rspace(
 //     let channel_slice = unsafe { std::slice::from_raw_parts(channel_pointer, channel_bytes_len) };
 //     let channel = Par::decode(channel_slice).unwrap();
 
-//     let joins = unsafe { (*rspace).rspace.lock().unwrap().get_joins(channel) };
+//     let joins = unsafe { (*rspace).rspace.lock().unwrap().get_joins(&channel) };
 
 //     let vec_join: Vec<JoinProto> = joins.into_iter().map(|join| JoinProto { join }).collect();
 //     let joins_proto = JoinsProto { joins: vec_join };

--- a/rspace++/src/rspace/hashing/stable_hash_provider.rs
+++ b/rspace++/src/rspace/hashing/stable_hash_provider.rs
@@ -36,35 +36,30 @@ pub fn hash_from_hashes(channels_hashes: &Vec<Blake2b256Hash>) -> Blake2b256Hash
 
 // See rspace/src/main/scala/coop/rchain/rspace/hashing/StableHashProvider.scala
 pub fn hash_consume<P: Serialize, K: Serialize>(
-    encoded_channels: Vec<Vec<u8>>,
-    patterns: &Vec<P>,
+    mut encoded_channels: Vec<Vec<u8>>,
+    patterns: &[P],
     continuation: &K,
-    persist: &bool,
+    persist: bool,
 ) -> Blake2b256Hash {
     let mut encoded_patterns = patterns
-        .into_iter()
+        .iter()
         .map(|pattern| bincode::serialize(pattern).unwrap())
         .collect::<Vec<_>>();
     encoded_patterns.sort();
 
     let encoded_continuation = bincode::serialize(continuation).unwrap();
-    let encoded_persist = bincode::serialize(persist).unwrap();
+    let encoded_persist = bincode::serialize(&persist).unwrap();
 
-    let mut encoded_vec = encoded_channels;
-    encoded_vec.extend(encoded_patterns);
-    encoded_vec.push(encoded_continuation);
-    encoded_vec.push(encoded_persist);
+    encoded_channels.extend(encoded_patterns);
+    encoded_channels.push(encoded_continuation);
+    encoded_channels.push(encoded_persist);
 
-    let encoded = bincode::serialize(&encoded_vec).unwrap();
+    let encoded = bincode::serialize(&encoded_channels).unwrap();
     Blake2b256Hash::new(&encoded)
 }
 
-pub fn hash_produce<A: Serialize>(
-    encoded_channel: Vec<u8>,
-    datum: &A,
-    persist: bool,
-) -> Blake2b256Hash {
-    let encoded_datum = bincode::serialize(&datum).unwrap();
+pub fn hash_produce<A: Serialize>(encoded_channel: Vec<u8>, datum: &A, persist: bool) -> Blake2b256Hash {
+    let encoded_datum = bincode::serialize(datum).unwrap();
     let encoded_persist = bincode::serialize(&persist).unwrap();
 
     let encoded_vec = vec![encoded_channel, encoded_datum, encoded_persist];

--- a/rspace++/src/rspace/hot_store.rs
+++ b/rspace++/src/rspace/hot_store.rs
@@ -15,19 +15,19 @@ use std::sync::{Arc, Mutex};
 
 // See rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
 pub trait HotStore<C: Clone + Hash + Eq, P: Clone, A: Clone, K: Clone>: Sync + Send {
-    fn get_continuations(&self, channels: Vec<C>) -> Vec<WaitingContinuation<P, K>>;
-    fn put_continuation(&self, channels: Vec<C>, wc: WaitingContinuation<P, K>) -> Option<()>;
-    fn install_continuation(&self, channels: Vec<C>, wc: WaitingContinuation<P, K>) -> Option<()>;
-    fn remove_continuation(&self, channels: Vec<C>, index: i32) -> Option<()>;
+    fn get_continuations(&self, channels: &[C]) -> Vec<WaitingContinuation<P, K>>;
+    fn put_continuation(&self, channels: &[C], wc: WaitingContinuation<P, K>) -> Option<()>;
+    fn install_continuation(&self, channels: &[C], wc: WaitingContinuation<P, K>) -> Option<()>;
+    fn remove_continuation(&self, channels: &[C], index: i32) -> Option<()>;
 
     fn get_data(&self, channel: &C) -> Vec<Datum<A>>;
-    fn put_datum(&self, channel: C, d: Datum<A>) -> ();
-    fn remove_datum(&self, channel: C, index: i32) -> Option<()>;
+    fn put_datum(&self, channel: &C, d: Datum<A>) -> ();
+    fn remove_datum(&self, channel: &C, index: i32) -> Option<()>;
 
-    fn get_joins(&self, channel: C) -> Vec<Vec<C>>;
-    fn put_join(&self, channel: C, join: Vec<C>) -> Option<()>;
-    fn install_join(&self, channel: C, join: Vec<C>) -> Option<()>;
-    fn remove_join(&self, channel: C, join: Vec<C>) -> Option<()>;
+    fn get_joins(&self, channel: &C) -> Vec<Vec<C>>;
+    fn put_join(&self, channel: &C, join: &[C]) -> Option<()>;
+    fn install_join(&self, channel: &C, join: &[C]) -> Option<()>;
+    fn remove_join(&self, channel: &C, join: &[C]) -> Option<()>;
 
     fn changes(&self) -> Vec<HotStoreAction<C, P, A, K>>;
     fn to_map(&self) -> HashMap<Vec<C>, Row<P, A, K>>;
@@ -150,78 +150,65 @@ where
 
     // Continuations
 
-    fn get_continuations(&self, channels: Vec<C>) -> Vec<WaitingContinuation<P, K>> {
+    fn get_continuations(&self, channels: &[C]) -> Vec<WaitingContinuation<P, K>> {
         let from_history_store: Vec<WaitingContinuation<P, K>> =
-            self.get_cont_from_history_store(&channels);
+            self.get_cont_from_history_store(channels);
 
-        let maybe_continuations = {
-            let state = self.hot_store_state.lock().unwrap();
-            state
-                .continuations
-                .get(&channels)
-                .map(|continuations| continuations.clone())
-        };
-
-        let maybe_installed_continuation = {
-            let state = self.hot_store_state.lock().unwrap();
-            state
-                .installed_continuations
-                .get(&channels)
-                .map(|continuations| continuations.clone())
-        };
-
-        match maybe_continuations {
-            Some(continuations) => match maybe_installed_continuation {
-                Some(installed_continuation) => {
-                    let mut result = vec![installed_continuation];
-                    result.extend(continuations);
-                    result
-                }
-                None => continuations,
+        let state = self.hot_store_state.lock().unwrap();
+        
+        // Clone the data we need to avoid lifetime issues
+        let continuations = state.continuations.get(channels).map(|c| c.clone());
+        let installed = state.installed_continuations.get(channels).map(|c| c.clone());
+        
+        match (continuations, installed) {
+            (Some(conts), Some(inst)) => {
+                let mut result = Vec::with_capacity(conts.len() + 1);
+                result.push(inst);
+                result.extend(conts);
+                result
             },
-            None => {
-                self.hot_store_state
-                    .lock()
-                    .unwrap()
-                    .continuations
-                    .insert(channels, from_history_store.clone());
-                match maybe_installed_continuation {
-                    Some(installed_continuation) => {
-                        let mut result = vec![installed_continuation];
-                        result.extend(from_history_store);
-                        result
-                    }
-                    None => from_history_store,
-                }
+            (Some(conts), None) => conts,
+            (None, Some(inst)) => {
+                state.continuations.insert(channels.to_vec(), from_history_store.clone());
+                let mut result = Vec::with_capacity(from_history_store.len() + 1);
+                result.push(inst);
+                result.extend(from_history_store);
+                result
+            },
+            (None, None) => {
+                state.continuations.insert(channels.to_vec(), from_history_store.clone());
+                from_history_store
             }
         }
     }
 
-    fn put_continuation(&self, channels: Vec<C>, wc: WaitingContinuation<P, K>) -> Option<()> {
+    fn put_continuation(&self, channels: &[C], wc: WaitingContinuation<P, K>) -> Option<()> {
         // println!("\nHit put_continuation");
 
         let from_history_store: Vec<WaitingContinuation<P, K>> =
-            self.get_cont_from_history_store(&channels);
+            self.get_cont_from_history_store(channels);
         // println!("\nfrom_history_store: {:?}", from_history_store);
 
         let state = self.hot_store_state.lock().unwrap();
         let current_continuations = state
             .continuations
-            .get(&channels)
+            .get(channels)
             .map(|c| c.clone())
             .unwrap_or(from_history_store);
-        let new_continuations = vec![wc]
-            .into_iter()
-            .chain(current_continuations.into_iter())
-            .collect();
-        state.continuations.insert(channels, new_continuations);
+        
+        // Pre-allocate with known capacity for better memory efficiency
+        let mut new_continuations = Vec::with_capacity(current_continuations.len() + 1);
+        new_continuations.push(wc);
+        new_continuations.extend(current_continuations);
+        
+        state.continuations.insert(channels.to_vec(), new_continuations);
         Some(())
     }
 
-    fn install_continuation(&self, channels: Vec<C>, wc: WaitingContinuation<P, K>) -> Option<()> {
+    fn install_continuation(&self, channels: &[C], wc: WaitingContinuation<P, K>) -> Option<()> {
         // println!("hit install_continuation");
         let state = self.hot_store_state.lock().unwrap();
-        let _ = state.installed_continuations.insert(channels, wc);
+        let _ = state.installed_continuations.insert(channels.to_vec(), wc);
 
         // println!("installed_continuation result: {:?}", result);
         // println!("to_map: {:?}\n", self.print());
@@ -229,17 +216,17 @@ where
         Some(())
     }
 
-    fn remove_continuation(&self, channels: Vec<C>, index: i32) -> Option<()> {
+    fn remove_continuation(&self, channels: &[C], index: i32) -> Option<()> {
         let from_history_store: Vec<WaitingContinuation<P, K>> =
-            self.get_cont_from_history_store(&channels);
+            self.get_cont_from_history_store(channels);
 
         let state = self.hot_store_state.lock().unwrap();
         let current_continuations = state
             .continuations
-            .get(&channels)
+            .get(channels)
             .map(|c| c.clone())
             .unwrap_or(from_history_store);
-        let installed_continuation = state.installed_continuations.get(&channels);
+        let installed_continuation = state.installed_continuations.get(channels);
         let is_installed = installed_continuation.is_some();
 
         let removing_installed = is_installed && index == 0;
@@ -252,17 +239,17 @@ where
             removed_index < 0 || removed_index as usize >= current_continuations.len();
 
         if removing_installed {
-            state.continuations.insert(channels, current_continuations);
+            state.continuations.insert(channels.to_vec(), current_continuations);
             println!("WARNING: Attempted to remove an installed continuation");
             None
         } else if out_of_bounds {
-            state.continuations.insert(channels, current_continuations);
+            state.continuations.insert(channels.to_vec(), current_continuations);
             println!("WARNING: Index {index} out of bounds when removing continuation");
             None
         } else {
             let mut new_continuations = current_continuations;
             new_continuations.remove(removed_index as usize);
-            state.continuations.insert(channels, new_continuations);
+            state.continuations.insert(channels.to_vec(), new_continuations);
             Some(())
         }
     }
@@ -292,173 +279,166 @@ where
         }
     }
 
-    fn put_datum(&self, channel: C, d: Datum<A>) -> () {
+    fn put_datum(&self, channel: &C, d: Datum<A>) -> () {
         // println!("\nHit put_datum, channel: {:?}, data: {:?}", channel, d);
         // println!("\nHit put_datum, data: {:?}", d);
 
-        let from_history_store: Vec<Datum<A>> = self.get_data_from_history_store(&channel);
+        let from_history_store: Vec<Datum<A>> = self.get_data_from_history_store(channel);
         // println!(
         //     "\nfrom_history_store in put_datum: {:?}",
         //     from_history_store
         // );
 
         let state = self.hot_store_state.lock().unwrap();
-        let mut update_data = state
-            .data
-            .get(&channel)
-            .map(|d| d.clone())
-            .unwrap_or(from_history_store);
-        update_data.insert(0, d);
-        let _ = state.data.insert(channel, update_data);
+        
+        let existing_data = state.data.get(channel).map(|d| d.clone());
+        
+        match existing_data {
+            Some(existing) => {
+                let mut new_data = Vec::with_capacity(existing.len() + 1);
+                new_data.push(d);
+                new_data.extend(existing);
+                state.data.insert(channel.clone(), new_data);
+            }
+            None => {
+                let mut new_data = Vec::with_capacity(from_history_store.len() + 1);
+                new_data.push(d);
+                new_data.extend(from_history_store);
+                state.data.insert(channel.clone(), new_data);
+            }
+        }
     }
 
-    fn remove_datum(&self, channel: C, index: i32) -> Option<()> {
-        let from_history_store: Vec<Datum<A>> = self.get_data_from_history_store(&channel);
+    fn remove_datum(&self, channel: &C, index: i32) -> Option<()> {
+        let from_history_store: Vec<Datum<A>> = self.get_data_from_history_store(channel);
 
         let state = self.hot_store_state.lock().unwrap();
         let current_datums = state
             .data
-            .get(&channel)
+            .get(channel)
             .map(|c| c.clone())
             .unwrap_or(from_history_store);
         let out_of_bounds = index as usize >= current_datums.len();
 
         if out_of_bounds {
-            state.data.insert(channel, current_datums);
+            state.data.insert(channel.clone(), current_datums);
             println!("WARNING: Index {index} out of bounds when removing datum");
             None
         } else {
             let mut new_datums = current_datums;
             new_datums.remove(index as usize);
-            state.data.insert(channel, new_datums);
+            state.data.insert(channel.clone(), new_datums);
             Some(())
         }
     }
 
     // Joins
 
-    fn get_joins(&self, channel: C) -> Vec<Vec<C>> {
+    fn get_joins(&self, channel: &C) -> Vec<Vec<C>> {
         // println!("\nHit get_joins");
 
-        let from_history_store: Vec<Vec<C>> = self.get_joins_from_history_store(&channel);
+        let from_history_store: Vec<Vec<C>> = self.get_joins_from_history_store(channel);
         // println!(
         //     "\nfrom_history_store in get_joins: {:?}",
         //     from_history_store
         // );
 
-        let maybe_joins = {
-            let state = self.hot_store_state.lock().unwrap();
-            state.joins.get(&channel).map(|joins| joins.clone())
-        };
-
-        match maybe_joins {
-            Some(joins) => {
+        let state = self.hot_store_state.lock().unwrap();
+        
+        let joins = state.joins.get(channel).map(|j| j.clone());
+        let installed_joins = state.installed_joins.get(channel).map(|j| j.clone());
+        
+        match joins {
+            Some(joins_data) => {
                 // println!("Found joins in store");
-                let installed_joins = {
-                    let state = self.hot_store_state.lock().unwrap();
-                    state
-                        .installed_joins
-                        .get(&channel)
-                        .map(|joins| joins.clone())
-                        .unwrap_or(Vec::new())
-                };
-
-                let mut result = installed_joins;
-                result.extend(joins);
+                let mut result = Vec::new();
+                if let Some(installed) = installed_joins {
+                    result.extend(installed);
+                }
+                result.extend(joins_data);
                 result
             }
             None => {
                 // println!("No joins found in store");
-                {
-                    let state = self.hot_store_state.lock().unwrap();
-                    state
-                        .joins
-                        .insert(channel.clone(), from_history_store.clone());
-                }
+                state.joins.insert(channel.clone(), from_history_store.clone());
                 // println!("Inserted into store. Returning from history");
 
-                let installed_joins = {
-                    let state = self.hot_store_state.lock().unwrap();
-                    state
-                        .installed_joins
-                        .get(&channel)
-                        .map(|joins| joins.clone())
-                        .unwrap_or(Vec::new())
-                };
-
-                let mut result = installed_joins;
+                let mut result = Vec::new();
+                if let Some(installed) = installed_joins {
+                    result.extend(installed);
+                }
                 result.extend(from_history_store);
                 result
             }
         }
     }
 
-    fn put_join(&self, channel: C, join: Vec<C>) -> Option<()> {
-        let from_history_store: Vec<Vec<C>> = self.get_joins_from_history_store(&channel);
+    fn put_join(&self, channel: &C, join: &[C]) -> Option<()> {
+        let from_history_store: Vec<Vec<C>> = self.get_joins_from_history_store(channel);
 
         let state = self.hot_store_state.lock().unwrap();
         let current_joins = state
             .joins
-            .get(&channel)
+            .get(channel)
             .map(|j| j.clone())
             .unwrap_or(from_history_store);
-        if current_joins.contains(&join) {
+        if current_joins.iter().any(|j| j.as_slice() == join) {
             Some(())
         } else {
-            let new_joins = vec![join]
-                .into_iter()
-                .chain(current_joins.into_iter())
-                .collect();
-            state.joins.insert(channel, new_joins);
+            let mut new_joins = Vec::with_capacity(current_joins.len() + 1);
+            new_joins.push(join.to_vec());
+            new_joins.extend(current_joins);
+            state.joins.insert(channel.clone(), new_joins);
             Some(())
         }
     }
 
-    fn install_join(&self, channel: C, join: Vec<C>) -> Option<()> {
+    fn install_join(&self, channel: &C, join: &[C]) -> Option<()> {
         // println!("hit install_join");
         let state = self.hot_store_state.lock().unwrap();
         let current_installed_joins = state
             .installed_joins
-            .get(&channel)
+            .get(channel)
             .map(|c| c.clone())
             .unwrap_or(Vec::new());
-        if !current_installed_joins.contains(&join) {
-            let mut new_installed_joins = current_installed_joins;
-            new_installed_joins.insert(0, join);
-            let _ = state.installed_joins.insert(channel, new_installed_joins);
+        if !current_installed_joins.iter().any(|j| j.as_slice() == join) {
+            let mut new_installed_joins = Vec::with_capacity(current_installed_joins.len() + 1);
+            new_installed_joins.push(join.to_vec());
+            new_installed_joins.extend(current_installed_joins);
+            let _ = state.installed_joins.insert(channel.clone(), new_installed_joins);
         }
         Some(())
     }
 
-    fn remove_join(&self, channel: C, join: Vec<C>) -> Option<()> {
-        let joins_in_history_store: Vec<Vec<C>> = self.get_joins_from_history_store(&channel);
+    fn remove_join(&self, channel: &C, join: &[C]) -> Option<()> {
+        let joins_in_history_store: Vec<Vec<C>> = self.get_joins_from_history_store(channel);
         let continuations_in_history_store: Vec<WaitingContinuation<P, K>> =
-            self.get_cont_from_history_store(&join);
+            self.get_cont_from_history_store(join);
 
         let state = self.hot_store_state.lock().unwrap();
         let current_joins = state
             .joins
-            .get(&channel)
+            .get(channel)
             .map(|j| j.clone())
             .unwrap_or(joins_in_history_store);
 
         let current_continuations = {
             let mut conts = state
                 .installed_continuations
-                .get(&join)
+                .get(join)
                 .map(|c| vec![c.clone()])
                 .unwrap_or_else(Vec::new);
             conts.extend(
                 state
                     .continuations
-                    .get(&join)
+                    .get(join)
                     .map(|continuations| continuations.clone())
                     .unwrap_or(continuations_in_history_store),
             );
             conts
         };
 
-        let index = current_joins.iter().position(|x| *x == join);
+        let index = current_joins.iter().position(|x| x.as_slice() == join);
         let out_of_bounds = index.is_none();
 
         // Remove join is called when continuation is removed, so it can be called when
@@ -468,16 +448,16 @@ where
         if do_remove {
             if out_of_bounds {
                 println!("WARNING: Join not found when removing join");
-                state.joins.insert(channel, current_joins);
+                state.joins.insert(channel.clone(), current_joins);
                 Some(())
             } else {
                 let mut new_joins = current_joins;
                 new_joins.remove(index.unwrap());
-                state.joins.insert(channel, new_joins);
+                state.joins.insert(channel.clone(), new_joins);
                 Some(())
             }
         } else {
-            state.joins.insert(channel, current_joins);
+            state.joins.insert(channel.clone(), current_joins);
             Some(())
         }
     }
@@ -636,7 +616,7 @@ where
         }
 
         // println!("\nHistory");
-        // println!("Continuations: {:?}", self.history_reader_base.get_continuations(channels));
+        // println!("Continuations: {:?}", self.history_reader_base.get_continuations(&channels));
     }
 
     fn clear(&self) {
@@ -666,13 +646,14 @@ where
     A: Clone + Debug + Sync + Send,
     K: Clone + Debug + Sync + Send,
 {
-    fn get_cont_from_history_store(&self, channels: &Vec<C>) -> Vec<WaitingContinuation<P, K>> {
+    fn get_cont_from_history_store(&self, channels: &[C]) -> Vec<WaitingContinuation<P, K>> {
         let cache = self.history_store_cache.lock().unwrap();
-        let entry = cache.continuations.entry(channels.clone());
+        let channels_vec = channels.to_vec();
+        let entry = cache.continuations.entry(channels_vec.clone());
         match entry {
             Entry::Occupied(o) => o.get().clone(),
             Entry::Vacant(v) => {
-                let ks = self.history_reader_base.get_continuations(channels);
+                let ks = self.history_reader_base.get_continuations(&channels_vec);
                 v.insert(ks.clone());
                 ks
             }
@@ -699,7 +680,7 @@ where
         match entry {
             Entry::Occupied(o) => o.get().clone(),
             Entry::Vacant(v) => {
-                let joins = self.history_reader_base.get_joins(channel);
+                let joins = self.history_reader_base.get_joins(&channel);
                 v.insert(joins.clone());
                 joins
             }

--- a/rspace++/src/rspace/rspace.rs
+++ b/rspace++/src/rspace/rspace.rs
@@ -128,11 +128,11 @@ where
     }
 
     fn get_waiting_continuations(&self, channels: Vec<C>) -> Vec<WaitingContinuation<P, K>> {
-        self.store.get_continuations(channels)
+        self.store.get_continuations(&channels)
     }
 
     fn get_joins(&self, channel: C) -> Vec<Vec<C>> {
-        self.store.get_joins(channel)
+        self.store.get_joins(&channel)
     }
 
     fn clear(&mut self) -> Result<(), RSpaceError> {
@@ -196,10 +196,11 @@ where
         } else if channels.len() != patterns.len() {
             panic!("RUST ERROR: channels.length must equal patterns.length");
         } else {
-            let consume_ref = Consume::create(&channels, &patterns, &continuation, persist);
+            let consume_ref =
+                Consume::create(&channels, &patterns, &continuation, persist);
 
             let result =
-                self.locked_consume(channels, patterns, continuation, persist, peeks, consume_ref);
+                self.locked_consume(&channels, &patterns, &continuation, persist, &peeks, &consume_ref);
             // println!("locked_consume result: {:?}", result);
             // println!("\nspace in consume after: {:?}", self.store.to_map().len());
             result
@@ -218,7 +219,7 @@ where
         // println!("\n\nHit produce, channel: {:?}", channel);
 
         let produce_ref = Produce::create(&channel, &data, persist);
-        let result = self.locked_produce(channel, data, persist, produce_ref);
+        let result = self.locked_produce(channel, data, persist, &produce_ref);
         // println!("\nlocked_produce result: {:?}", result);
         // println!("\nspace in produce: {:?}", self.store.to_map().len());
         result
@@ -434,12 +435,12 @@ where
 
     fn locked_consume(
         &mut self,
-        channels: Vec<C>,
-        patterns: Vec<P>,
-        continuation: K,
+        channels: &[C],
+        patterns: &[P],
+        continuation: &K,
         persist: bool,
-        peeks: BTreeSet<i32>,
-        consume_ref: Consume,
+        peeks: &BTreeSet<i32>,
+        consume_ref: &Consume,
     ) -> Result<MaybeConsumeResult<C, P, A, K>, RSpaceError> {
         // println!("\nHit locked_consume");
         // println!(
@@ -447,9 +448,9 @@ where
         //     patterns, channels
         // );
 
-        self.log_consume(consume_ref.clone(), &channels, &patterns, &continuation, persist, &peeks);
+        self.log_consume(consume_ref, channels, patterns, continuation, persist, peeks);
 
-        let channel_to_indexed_data = self.fetch_channel_to_index_data(&channels);
+        let channel_to_indexed_data = self.fetch_channel_to_index_data(channels);
         // println!("\nchannel_to_indexed_data: {:?}", channel_to_indexed_data);
         let zipped: Vec<(C, P)> = channels
             .iter()
@@ -464,8 +465,8 @@ where
         // println!("options: {:?}", options);
 
         let wk = WaitingContinuation {
-            patterns,
-            continuation,
+            patterns: patterns.to_vec(),
+            continuation: continuation.clone(),
             persist,
             peeks: peeks.clone(),
             source: consume_ref.clone(),
@@ -478,8 +479,8 @@ where
 
                 self.log_comm(
                     &data_candidates,
-                    &channels,
-                    wk.clone(),
+                    channels,
+                    &wk,
                     COMM::new(
                         data_candidates.clone(),
                         consume_ref.clone(),
@@ -488,15 +489,15 @@ where
                     ),
                     CONSUME_COMM_LABEL,
                 );
-                self.store_persistent_data(data_candidates.clone(), &peeks);
+                self.store_persistent_data(&data_candidates, peeks);
                 // println!(
                 //     "consume: data found for <patterns: {:?}> at <channels: {:?}>",
                 //     patterns, channels
                 // );
-                Ok(self.wrap_result(channels, wk, consume_ref, data_candidates))
+                Ok(self.wrap_result(channels, &wk, consume_ref, &data_candidates))
             }
             None => {
-                self.store_waiting_continuation(channels, wk);
+                self.store_waiting_continuation(channels.to_vec(), wk);
                 Ok(None)
             }
         }
@@ -510,8 +511,8 @@ where
      * Put another way, this allows us to speculatively remove matching data without
      * affecting the actual store contents.
      */
-    fn fetch_channel_to_index_data(&self, channels: &Vec<C>) -> DashMap<C, Vec<(Datum<A>, i32)>> {
-        let map = DashMap::new();
+    fn fetch_channel_to_index_data(&self, channels: &[C]) -> DashMap<C, Vec<(Datum<A>, i32)>> {
+        let map = DashMap::with_capacity(channels.len());
         for c in channels {
             let data = self.store.get_data(c);
             let shuffled_data = self.shuffle_with_index(data);
@@ -525,33 +526,29 @@ where
         channel: C,
         data: A,
         persist: bool,
-        produce_ref: Produce,
+        produce_ref: &Produce,
     ) -> Result<MaybeProduceResult<C, P, A, K>, RSpaceError> {
         // println!("\nHit locked_produce");
-        let grouped_channels = self.store.get_joins(channel.clone());
+        let grouped_channels = self.store.get_joins(&channel);
         // println!("\ngrouped_channels: {:?}", grouped_channels);
         // println!(
         //     "produce: searching for matching continuations at <grouped_channels: {:?}>",
         //     grouped_channels
         // );
-        let _ = self.log_produce(produce_ref.clone(), &channel, &data, persist);
-        let extracted = self.extract_produce_candidate(
-            grouped_channels,
-            channel.clone(),
-            Datum {
-                a: data.clone(),
-                persist,
-                source: produce_ref.clone(),
-            },
-        );
+        self.log_produce(produce_ref, &channel, &data, persist);
+        let extracted = self.extract_produce_candidate(grouped_channels, channel.clone(), Datum {
+            a: data.clone(),
+            persist,
+            source: produce_ref.clone(),
+        });
 
         // println!("extracted in lockedProduce: {:?}", extracted);
 
         match extracted {
             Some(produce_candidate) => Ok(self
                 .process_match_found(produce_candidate)
-                .map(|consume_result| (consume_result.0, consume_result.1, produce_ref))),
-            None => Ok(self.store_data(channel, data, persist, produce_ref)),
+                .map(|consume_result| (consume_result.0, consume_result.1, produce_ref.clone()))),
+            None => Ok(self.store_data(channel, data, persist, produce_ref.clone())),
         }
     }
 
@@ -571,7 +568,7 @@ where
 
         let fetch_matching_continuations =
             |channels: Vec<C>| -> Vec<(WaitingContinuation<P, K>, i32)> {
-                let continuations = self.store.get_continuations(channels);
+                let continuations = self.store.get_continuations(&channels);
                 self.shuffle_with_index(continuations)
             };
 
@@ -624,7 +621,7 @@ where
         self.log_comm(
             &data_candidates,
             &channels,
-            continuation.clone(),
+            &continuation,
             COMM::new(
                 data_candidates.clone(),
                 consume_ref.clone(),
@@ -636,7 +633,7 @@ where
 
         if !persist {
             self.store
-                .remove_continuation(channels.clone(), continuation_index);
+                .remove_continuation(&channels, continuation_index);
         }
 
         self.remove_matched_datum_and_join(channels.clone(), data_candidates.clone());
@@ -646,57 +643,52 @@ where
         //     channels
         // );
 
-        self.wrap_result(channels, continuation.clone(), consume_ref.clone(), data_candidates)
+        self.wrap_result(&channels, &continuation, consume_ref, &data_candidates)
     }
 
     fn log_comm(
         &mut self,
         _data_candidates: &Vec<ConsumeCandidate<C, A>>,
-        _channels: &Vec<C>,
-        _wk: WaitingContinuation<P, K>,
+        _channels: &[C],
+        _wk: &WaitingContinuation<P, K>,
         comm: COMM,
         _label: &str,
-    ) -> COMM {
-        self.event_log.insert(0, Event::Comm(comm.clone()));
-        comm
+    ) {
+        self.event_log.insert(0, Event::Comm(comm));
     }
 
     fn log_consume(
         &mut self,
-        consume_ref: Consume,
-        _channels: &Vec<C>,
-        _patterns: &Vec<P>,
+        consume_ref: &Consume,
+        _channels: &[C],
+        _patterns: &[P],
         _continuation: &K,
         _persist: bool,
         _peeks: &BTreeSet<i32>,
-    ) -> Consume {
+    ) {
         self.event_log
             .insert(0, Event::IoEvent(IOEvent::Consume(consume_ref.clone())));
-
-        consume_ref
     }
 
     fn log_produce(
         &mut self,
-        produce_ref: Produce,
+        produce_ref: &Produce,
         _channel: &C,
         _data: &A,
         persist: bool,
-    ) -> Produce {
+    ) {
         self.event_log
             .insert(0, Event::IoEvent(IOEvent::Produce(produce_ref.clone())));
         if !persist {
             // let entry = self.produce_counter.entry(produce_ref.clone()).or_insert(0);
             // *entry += 1;
-            match self.produce_counter.get(&produce_ref) {
+            match self.produce_counter.get(produce_ref) {
                 Some(current_count) => self
                     .produce_counter
                     .insert(produce_ref.clone(), current_count + 1),
                 None => self.produce_counter.insert(produce_ref.clone(), 1),
             };
         }
-
-        produce_ref
     }
 
     pub fn spawn(&self) -> Result<Self, RSpaceError> {
@@ -724,9 +716,9 @@ where
         wc: WaitingContinuation<P, K>,
     ) -> MaybeConsumeResult<C, P, A, K> {
         // println!("\nHit store_waiting_continuation");
-        self.store.put_continuation(channels.clone(), wc);
+        self.store.put_continuation(&channels, wc);
         for channel in channels.iter() {
-            self.store.put_join(channel.clone(), channels.clone());
+            self.store.put_join(channel, &channels);
             // println!("consume: no data found, storing <(patterns, continuation): ({:?}, {:?})> at <channels: {:?}>", wc.patterns, wc.continuation, channels)
         }
         None
@@ -741,14 +733,11 @@ where
     ) -> MaybeProduceResult<C, P, A, K> {
         // println!("\nHit store_data");
         // println!("\nHit store_data, data: {:?}", data);
-        self.store.put_datum(
-            channel,
-            Datum {
-                a: data,
-                persist,
-                source: produce_ref,
-            },
-        );
+        self.store.put_datum(&channel, Datum {
+            a: data,
+            persist,
+            source: produce_ref,
+        });
         // println!(
         //     "produce: persisted <data: {:?}> at <channel: {:?}>",
         //     data, channel
@@ -759,11 +748,12 @@ where
 
     fn store_persistent_data(
         &self,
-        mut data_candidates: Vec<ConsumeCandidate<C, A>>,
+        data_candidates: &Vec<ConsumeCandidate<C, A>>,
         _peeks: &BTreeSet<i32>,
     ) -> Option<Vec<()>> {
-        data_candidates.sort_by(|a, b| b.datum_index.cmp(&a.datum_index));
-        let results: Vec<_> = data_candidates
+        let mut sorted_candidates: Vec<_> = data_candidates.iter().collect();
+        sorted_candidates.sort_by(|a, b| b.datum_index.cmp(&a.datum_index));
+        let results: Vec<_> = sorted_candidates
             .into_iter()
             .rev()
             .map(|consume_candidate| {
@@ -775,7 +765,7 @@ where
                 } = consume_candidate;
 
                 if !persist {
-                    self.store.remove_datum(channel, datum_index)
+                    self.store.remove_datum(channel, *datum_index)
                 } else {
                     Some(())
                 }
@@ -817,7 +807,8 @@ where
             //     patterns, channels
             // );
 
-            let consume_ref = Consume::create(&channels, &patterns, &continuation, true);
+            let consume_ref =
+                Consume::create(&channels, &patterns, &continuation, true);
             let channel_to_indexed_data = self.fetch_channel_to_index_data(&channels);
             // println!("channel_to_indexed_data in locked_install: {:?}", channel_to_indexed_data);
             let zipped: Vec<(C, P)> = channels
@@ -842,9 +833,8 @@ where
                         },
                     );
 
-                    self.store.install_continuation(
-                        channels.clone(),
-                        WaitingContinuation {
+                    self.store
+                        .install_continuation(&channels, WaitingContinuation {
                             patterns,
                             continuation,
                             persist: true,
@@ -854,7 +844,7 @@ where
                     );
 
                     for channel in channels.iter() {
-                        self.store.install_join(channel.clone(), channels.clone());
+                        self.store.install_join(channel, &channels);
                     }
                     // println!(
                     //     "storing <(patterns, continuation): ({:?}, {:?})> at <channels: {:?}>",
@@ -880,27 +870,27 @@ where
 
     fn wrap_result(
         &self,
-        channels: Vec<C>,
-        wk: WaitingContinuation<P, K>,
-        _consume_ref: Consume,
-        data_candidates: Vec<ConsumeCandidate<C, A>>,
+        channels: &[C],
+        wk: &WaitingContinuation<P, K>,
+        _consume_ref: &Consume,
+        data_candidates: &Vec<ConsumeCandidate<C, A>>,
     ) -> MaybeConsumeResult<C, P, A, K> {
         // println!("\nhit wrap_result");
 
         let cont_result = ContResult {
-            continuation: wk.continuation,
+            continuation: wk.continuation.clone(),
             persistent: wk.persist,
-            channels,
-            patterns: wk.patterns,
+            channels: channels.to_vec(),
+            patterns: wk.patterns.clone(),
             peek: !wk.peeks.is_empty(),
         };
 
         let rspace_results = data_candidates
-            .into_iter()
+            .iter()
             .map(|data_candidate| RSpaceResult {
-                channel: data_candidate.channel,
-                matched_datum: data_candidate.datum.a,
-                removed_datum: data_candidate.removed_datum,
+                channel: data_candidate.channel.clone(),
+                matched_datum: data_candidate.datum.a.clone(),
+                removed_datum: data_candidate.removed_datum.clone(),
                 persistent: data_candidate.datum.persist,
             })
             .collect();
@@ -925,11 +915,10 @@ where
                     datum_index,
                 } = consume_candidate;
 
-                let channels_clone = channels.clone();
                 if datum_index >= 0 && !persist {
-                    self.store.remove_datum(channel.clone(), datum_index);
+                    self.store.remove_datum(&channel, datum_index);
                 }
-                self.store.remove_join(channel, channels_clone);
+                self.store.remove_join(&channel, &channels);
 
                 Some(())
             })

--- a/rspace++/src/rspace/trace/event.rs
+++ b/rspace++/src/rspace/trace/event.rs
@@ -172,7 +172,7 @@ impl Consume {
         let channel_hashes = hash_vec(channels);
         let channels_encoded_sorted: Vec<Vec<u8>> =
             channel_hashes.iter().map(|hash| hash.bytes()).collect();
-        let hash = hash_consume(channels_encoded_sorted, &patterns, &continuation, &persistent);
+        let hash = hash_consume(channels_encoded_sorted, &patterns, &continuation, persistent);
         Consume {
             channel_hashes,
             hash,

--- a/rspace++/tests/hot_store_spec.rs
+++ b/rspace++/tests/hot_store_spec.rs
@@ -55,7 +55,7 @@ proptest! {
       assert!(cache.continuations.is_empty());
       drop(cache);
 
-      let read_continuations = hot_store.get_continuations(channels.clone());
+      let read_continuations = hot_store.get_continuations(&channels.clone());
       let cache = state.lock().unwrap();
       assert_eq!(cache.continuations.get(&channels).unwrap().clone(), history_continuations);
       assert_eq!(read_continuations, history_continuations);
@@ -71,7 +71,7 @@ proptest! {
       *state_lock = HotStoreState { continuations: DashMap::from_iter(vec![(channels.clone(), cached_continuations.clone())]), installed_continuations: DashMap::new(), data: DashMap::new(), joins: DashMap::new(), installed_joins: DashMap::new() };
       drop(state_lock);
 
-      let read_continuations = hot_store.get_continuations(channels.clone());
+      let read_continuations = hot_store.get_continuations(&channels.clone());
       let cache = state.lock().unwrap();
       assert_eq!(cache.continuations.get(&channels).unwrap().clone(), cached_continuations);
       assert_eq!(read_continuations, cached_continuations);
@@ -86,8 +86,8 @@ proptest! {
       *state_lock = HotStoreState { continuations: DashMap::from_iter(vec![(channels.clone(), cached_continuations.clone())]), installed_continuations: DashMap::new(), data: DashMap::new(), joins: DashMap::new(), installed_joins: DashMap::new() };
       drop(state_lock);
 
-      hot_store.install_continuation(channels.clone(), installed_continuation.clone());
-      let res = hot_store.get_continuations(channels);
+      hot_store.install_continuation(&channels.clone(), installed_continuation.clone());
+      let res = hot_store.get_continuations(&channels);
       cached_continuations.insert(0, installed_continuation);
       assert_eq!(res, cached_continuations);
   }
@@ -98,7 +98,7 @@ proptest! {
       let (state, history, hot_store) = fixture();
 
       history.put_continuations(channels.clone(), history_continuations.clone());
-      hot_store.put_continuation(channels.clone(), inserted_continuation.clone());
+      hot_store.put_continuation(&channels.clone(), inserted_continuation.clone());
 
       let cache = state.lock().unwrap();
       history_continuations.insert(0, inserted_continuation);
@@ -115,7 +115,7 @@ proptest! {
       *state_lock = HotStoreState { continuations: DashMap::from_iter(vec![(channels.clone(), cached_continuations.clone())]), installed_continuations: DashMap::new(), data: DashMap::new(), joins: DashMap::new(), installed_joins: DashMap::new() };
       drop(state_lock);
 
-      hot_store.put_continuation(channels.clone(),inserted_continuation.clone());
+      hot_store.put_continuation(&channels.clone(),inserted_continuation.clone());
 
       let cache = state.lock().unwrap();
       cached_continuations.insert(0, inserted_continuation);
@@ -132,8 +132,8 @@ proptest! {
       *state_lock = HotStoreState { continuations: DashMap::from_iter(vec![(channels.clone(), cached_continuations.clone())]), installed_continuations: DashMap::new(), data: DashMap::new(), joins: DashMap::new(), installed_joins: DashMap::new() };
       drop(state_lock);
 
-      hot_store.install_continuation(channels.clone(), installed_continuation.clone());
-      hot_store.put_continuation(channels.clone(), inserted_continuation.clone());
+      hot_store.install_continuation(&channels.clone(), installed_continuation.clone());
+      hot_store.put_continuation(&channels.clone(), inserted_continuation.clone());
 
       let cache = state.lock().unwrap();
       cached_continuations.insert(0, inserted_continuation);
@@ -147,7 +147,7 @@ proptest! {
       let (state, history, hot_store) = fixture();
 
       history.put_continuations(channels.clone(), history_continuations.clone());
-      let res = hot_store.remove_continuation(channels.clone(), index);
+      let res = hot_store.remove_continuation(&channels.clone(), index);
 
       let state_lock = state.lock().unwrap();
       assert!(check_removal_works_or_fails_on_error(res, state_lock.continuations.get(&channels).map_or(Vec::new(), |x| x.clone()), history_continuations, index).is_ok());
@@ -163,7 +163,7 @@ proptest! {
       *state_lock = HotStoreState { continuations: DashMap::from_iter(vec![(channels.clone(), cached_continuations.clone())]), installed_continuations: DashMap::new(), data: DashMap::new(), joins: DashMap::new(), installed_joins: DashMap::new() };
       drop(state_lock);
 
-      let res = hot_store.remove_continuation(channels.clone(), index);
+      let res = hot_store.remove_continuation(&channels.clone(), index);
       let state_lock = state.lock().unwrap();
       assert!(check_removal_works_or_fails_on_error(res, state_lock.continuations.get(&channels).map_or(Vec::new(), |x| x.clone()), cached_continuations, index).is_ok());
   }
@@ -178,12 +178,12 @@ proptest! {
         data: DashMap::new(), joins: DashMap::new(), installed_joins: DashMap::new() };
       drop(state_lock);
 
-      let res = hot_store.remove_continuation(channels.clone(), index);
+      let res = hot_store.remove_continuation(&channels.clone(), index);
       if index == 0 {
         assert!(res.is_none());
       } else {
         // index of the removed continuation includes the installed
-        let conts = hot_store.get_continuations(channels);
+        let conts = hot_store.get_continuations(&channels);
         cached_continuations.insert(0, installed_continuation);
         assert!(check_removal_works_or_fails_on_error(res, conts, cached_continuations, index).is_ok());
       }
@@ -226,7 +226,7 @@ proptest! {
       let (state, history, hot_store) = fixture();
 
       history.put_data(channel.clone(), history_data.clone());
-      hot_store.put_datum(channel.clone(), inserted_data.clone());
+      hot_store.put_datum(&channel.clone(), inserted_data.clone());
 
       let cache = state.lock().unwrap();
       history_data.insert(0, inserted_data);
@@ -243,7 +243,7 @@ proptest! {
       *cache = HotStoreState { continuations: DashMap::new(), installed_continuations: DashMap::new(), data: DashMap::from_iter(vec![(channel.clone(), cached_data.clone())]), joins: DashMap::new(), installed_joins: DashMap::new() };
       drop(cache);
 
-      hot_store.put_datum(channel.clone(), inserted_data.clone());
+      hot_store.put_datum(&channel.clone(), inserted_data.clone());
       let cache = state.lock().unwrap();
       cached_data.insert(0, inserted_data);
       assert_eq!(cache.data.get(&channel).unwrap().clone(), cached_data);
@@ -255,7 +255,7 @@ proptest! {
       let (state, history, hot_store) = fixture();
 
       history.put_data(channel.clone(), history_data.clone());
-      let res = hot_store.remove_datum(channel.clone(), index);
+      let res = hot_store.remove_datum(&channel.clone(), index);
 
       let cache = state.lock().unwrap();
       assert!(check_removal_works_or_fails_on_error(res, cache.data.get(&channel).map_or(Vec::new(), |x| x.clone()), history_data, index).is_ok());
@@ -271,7 +271,7 @@ proptest! {
       *cache = HotStoreState { continuations: DashMap::new(), installed_continuations: DashMap::new(), data: DashMap::from_iter(vec![(channel.clone(), cached_data.clone())]), joins: DashMap::new(), installed_joins: DashMap::new() };
       drop(cache);
 
-      let res = hot_store.remove_datum(channel.clone(), index);
+      let res = hot_store.remove_datum(&channel.clone(), index);
       let cache = state.lock().unwrap();
       assert!(check_removal_works_or_fails_on_error(res, cache.data.get(&channel).unwrap().clone(), cached_data, index).is_ok());
   }
@@ -285,7 +285,7 @@ proptest! {
       assert!(cache.joins.is_empty());
       drop(cache);
 
-      let read_joins = hot_store.get_joins(channel.clone());
+      let read_joins = hot_store.get_joins(&channel.clone());
       let cache = state.lock().unwrap();
       assert_eq!(cache.joins.get(&channel).unwrap().clone(), history_joins);
       assert_eq!(read_joins, history_joins);
@@ -301,7 +301,7 @@ proptest! {
       *cache = HotStoreState { continuations: DashMap::new(), installed_continuations: DashMap::new(), data: DashMap::new(), joins: DashMap::from_iter(vec![(channel.clone(), cached_joins.clone())]), installed_joins: DashMap::new() };
       drop(cache);
 
-      let read_joins = hot_store.get_joins(channel.clone());
+      let read_joins = hot_store.get_joins(&channel.clone());
       let cache = state.lock().unwrap();
       assert_eq!(cache.joins.get(&channel).unwrap().clone(), cached_joins);
       assert_eq!(read_joins, cached_joins);
@@ -313,7 +313,7 @@ proptest! {
       let (state, history, hot_store) = fixture();
 
       history.put_joins(channel.clone(), history_joins.clone());
-      hot_store.put_join(channel.clone(), inserted_join.clone());
+      hot_store.put_join(&channel.clone(), &inserted_join.clone());
 
       let cache = state.lock().unwrap();
       history_joins.insert(0, inserted_join);
@@ -331,7 +331,7 @@ proptest! {
       *cache = HotStoreState { continuations: DashMap::new(), installed_continuations: DashMap::new(), data: DashMap::new(), joins: DashMap::from_iter(vec![(channel.clone(), cached_joins.clone())]), installed_joins: DashMap::new() };
       drop(cache);
 
-      hot_store.put_join(channel.clone(), inserted_join.clone());
+      hot_store.put_join(&channel.clone(), &inserted_join.clone());
       let cache = state.lock().unwrap();
       cached_joins.insert(0, inserted_join);
       assert_eq!(cache.joins.get(&channel).unwrap().clone(), cached_joins);
@@ -345,7 +345,7 @@ proptest! {
       *cache = HotStoreState { continuations: DashMap::new(), installed_continuations: DashMap::new(), data: DashMap::new(), joins: DashMap::from_iter(vec![(channel.clone(), cached_joins.clone())]), installed_joins: DashMap::new() };
       drop(cache);
 
-      hot_store.put_join(channel.clone(), inserted_join.clone());
+      hot_store.put_join(&channel.clone(), &inserted_join.clone());
       let cache = state.lock().unwrap();
 
       if !cached_joins.contains(&inserted_join) {
@@ -366,8 +366,8 @@ proptest! {
       *cache = HotStoreState { continuations: DashMap::new(), installed_continuations: DashMap::new(), data: DashMap::new(), joins: DashMap::from_iter(vec![(channel.clone(), cached_joins.clone())]), installed_joins: DashMap::new() };
       drop(cache);
 
-      hot_store.put_join(channel.clone(), inserted_join.clone());
-      hot_store.install_join(channel.clone(), installed_join.clone());
+      hot_store.put_join(&channel.clone(), &inserted_join.clone());
+      hot_store.install_join(&channel.clone(), &installed_join.clone());
 
       let cache = state.lock().unwrap();
       assert_eq!(cache.installed_joins.get(&channel).unwrap().clone(), vec![installed_join]);
@@ -383,8 +383,8 @@ proptest! {
       *cache = HotStoreState { continuations: DashMap::new(), installed_continuations: DashMap::new(), data: DashMap::new(), joins: DashMap::from_iter(vec![(channel.clone(), cached_joins.clone())]), installed_joins: DashMap::new() };
       drop(cache);
 
-      hot_store.install_join(channel.clone(), installed_join.clone());
-      hot_store.install_join(channel.clone(), installed_join.clone());
+      hot_store.install_join(&channel.clone(), &installed_join.clone());
+      hot_store.install_join(&channel.clone(), &installed_join.clone());
 
       let cache = state.lock().unwrap();
       assert_eq!(cache.installed_joins.get(&channel).unwrap().clone(), vec![installed_join]);
@@ -397,7 +397,7 @@ proptest! {
 
       history.put_joins(channel.clone(), history_joins.clone());
       let to_remove = history_joins.get(index as usize).unwrap_or(&join).clone();
-      let res = hot_store.remove_join(channel.clone(), to_remove);
+      let res = hot_store.remove_join(&channel.clone(), &to_remove);
 
       let cache = state.lock().unwrap();
       assert!(check_removal_works_or_ignores_errors(res, cache.joins.get(&channel).unwrap().clone(), history_joins, index).is_ok());
@@ -415,7 +415,7 @@ proptest! {
       *cache = HotStoreState { continuations: DashMap::new(), installed_continuations: DashMap::new(), data: DashMap::new(), joins: DashMap::from_iter(vec![(channel.clone(), cached_joins.clone())]), installed_joins: DashMap::new() };
       drop(cache);
 
-      let res = hot_store.remove_join(channel.clone(), to_remove);
+      let res = hot_store.remove_join(&channel.clone(), &to_remove);
       let cache = state.lock().unwrap();
       assert!(check_removal_works_or_ignores_errors(res, cache.joins.get(&channel).unwrap().clone(), cached_joins, index).is_ok());
   }
@@ -435,7 +435,7 @@ proptest! {
       shuffled_joins.shuffle(&mut rng);
       let to_remove = shuffled_joins.first().unwrap().clone();
 
-      let res = hot_store.remove_join(channel.clone(), to_remove.clone());
+      let res = hot_store.remove_join(&channel.clone(), &to_remove.clone());
       let cache = state.lock().unwrap();
 
       if !cached_joins.contains(&to_remove) {
@@ -464,8 +464,8 @@ proptest! {
       shuffled_joins.shuffle(&mut rng);
       let to_remove = shuffled_joins.first().unwrap().clone();
 
-      hot_store.put_continuation(to_remove.clone(), continuation);
-      let res = hot_store.remove_join(channel.clone(), to_remove.clone());
+      hot_store.put_continuation(&to_remove.clone(), continuation);
+      let res = hot_store.remove_join(&channel.clone(), &to_remove.clone());
       let cache = state.lock().unwrap();
 
       assert!(res.is_some());
@@ -529,11 +529,11 @@ proptest! {
       // Spawn two threads to run put_datum in parallel and waits for both threads to complete using join.
       let handle1 = std::thread::spawn(move || {
         let hot_store = hot_store1.lock().unwrap();
-        hot_store.put_datum(channel1_clone, inserted_data1_clone);
+        hot_store.put_datum(&channel1_clone, inserted_data1_clone);
       });
       let handle2 = std::thread::spawn(move || {
         let hot_store = hot_store2.lock().unwrap();
-        hot_store.put_datum(channel2_clone, inserted_data2_clone);
+        hot_store.put_datum(&channel2_clone, inserted_data2_clone);
       });
       handle1.join().unwrap();
       handle2.join().unwrap();
@@ -570,17 +570,17 @@ proptest! {
       // Spawn two threads to run put_datum in parallel and waits for both threads to complete using join.
       let handle1 = std::thread::spawn(move || {
         let hot_store = hot_store1.lock().unwrap();
-        hot_store.put_continuation(channels1_clone, inserted_continuation1_clone);
+        hot_store.put_continuation(&channels1_clone, inserted_continuation1_clone);
       });
       let handle2 = std::thread::spawn(move || {
         let hot_store = hot_store2.lock().unwrap();
-        hot_store.put_continuation(channels2_clone, inserted_continuation2_clone);
+        hot_store.put_continuation(&channels2_clone, inserted_continuation2_clone);
       });
       handle1.join().unwrap();
       handle2.join().unwrap();
 
-      let r1 = hot_store.lock().unwrap().get_continuations(channels1);
-      let r2 = hot_store.lock().unwrap().get_continuations(channels2);
+      let r1 = hot_store.lock().unwrap().get_continuations(&channels1);
+      let r2 = hot_store.lock().unwrap().get_continuations(&channels2);
       history_continuations1.insert(0, inserted_continuation1);
       history_continuations2.insert(0, inserted_continuation2);
 
@@ -596,7 +596,7 @@ proptest! {
       let key = channel.clone();
       let datum = Datum::create(&channel, datum_value, false);
 
-      hot_store.put_datum(key.clone(), datum.clone());
+      hot_store.put_datum(&key.clone(), datum.clone());
       let res = hot_store.get_data(&key);
       assert!(check_same_elements(res, vec![datum]));
   }
@@ -608,8 +608,8 @@ proptest! {
       let datum1 = Datum::create(&channel, datum_value.clone(), false);
       let datum2 = Datum::create(&channel, datum_value + "2", false);
 
-      hot_store.put_datum(key.clone(), datum1.clone());
-      hot_store.put_datum(key.clone(), datum2.clone());
+      hot_store.put_datum(&key.clone(), datum1.clone());
+      hot_store.put_datum(&key.clone(), datum2.clone());
       let res = hot_store.get_data(&key);
       assert!(check_same_elements(res, vec![datum1, datum2]));
   }
@@ -625,10 +625,10 @@ proptest! {
         .collect();
 
       for d in data.clone() {
-        hot_store.put_datum(key.clone(), d);
+        hot_store.put_datum(&key.clone(), d);
       }
 
-      hot_store.remove_datum(key.clone(), index - 1);
+      hot_store.remove_datum(&key.clone(), index - 1);
       let res = hot_store.get_data(&key);
       let expected: Vec<Datum<String>> = data.into_iter()
          .filter(|d| d.a != datum_value.clone() + &(11 - index).to_string())
@@ -642,10 +642,10 @@ proptest! {
       let key = vec![channel.clone()];
       let patterns = vec![Pattern::StringMatch(pattern)];
       let continuation = StringsCaptor::new();
-      let wc = WaitingContinuation::create(&key, patterns, continuation, false, BTreeSet::default());
+      let wc = WaitingContinuation::create(&key, &patterns, &continuation, false, BTreeSet::default());
 
-      hot_store.put_continuation(key.clone(), wc.clone());
-      let res = hot_store.get_continuations(key);
+      hot_store.put_continuation(&key.clone(), wc.clone());
+      let res = hot_store.get_continuations(&key);
       assert_eq!(res, vec![wc]);
   }
 
@@ -655,12 +655,12 @@ proptest! {
       let key = vec![channel.clone()];
       let patterns = vec![Pattern::StringMatch(pattern.clone())];
       let continuation = StringsCaptor::new();
-      let wc1 = WaitingContinuation::create(&key, patterns, continuation.clone(), false, BTreeSet::default());
-      let wc2 = WaitingContinuation::create(&key, vec![Pattern::StringMatch(pattern + "2")], continuation, false, BTreeSet::default());
+      let wc1 = WaitingContinuation::create(&key, &patterns, &continuation, false, BTreeSet::default());
+      let wc2 = WaitingContinuation::create(&key, &vec![Pattern::StringMatch(pattern + "2")], &continuation, false, BTreeSet::default());
 
-      hot_store.put_continuation(key.clone(), wc1.clone());
-      hot_store.put_continuation(key.clone(), wc2.clone());
-      let res = hot_store.get_continuations(key);
+      hot_store.put_continuation(&key.clone(), wc1.clone());
+      hot_store.put_continuation(&key.clone(), wc2.clone());
+      let res = hot_store.get_continuations(&key);
       assert!(check_same_elements(res, vec![wc1, wc2]));
   }
 
@@ -670,13 +670,13 @@ proptest! {
       let key = vec![channel.clone()];
       let patterns = vec![Pattern::StringMatch(pattern.clone())];
       let continuation = StringsCaptor::new();
-      let wc1 = WaitingContinuation::create(&key, patterns, continuation.clone(), false, BTreeSet::default());
-      let wc2 = WaitingContinuation::create(&key, vec![Pattern::StringMatch(pattern + "2")], continuation, false, BTreeSet::default());
+      let wc1 = WaitingContinuation::create(&key, &patterns, &continuation, false, BTreeSet::default());
+      let wc2 = WaitingContinuation::create(&key, &vec![Pattern::StringMatch(pattern + "2")], &continuation, false, BTreeSet::default());
 
-      hot_store.put_continuation(key.clone(), wc1.clone());
-      hot_store.put_continuation(key.clone(), wc2.clone());
-      hot_store.remove_continuation(key.clone(), 0);
-      let res = hot_store.get_continuations(key);
+      hot_store.put_continuation(&key.clone(), wc1.clone());
+      hot_store.put_continuation(&key.clone(), wc2.clone());
+      hot_store.remove_continuation(&key.clone(), 0);
+      let res = hot_store.get_continuations(&key);
       assert!(check_same_elements(res, vec![wc1]));
   }
 
@@ -684,8 +684,8 @@ proptest! {
   fn add_join_should_add_join_for_a_channel(channel in  any::<String>(), channels in vec(any::<String>(), 0..=SIZE_RANGE)) {
       let (_, _, hot_store) = fixture();
 
-      hot_store.put_join(channel.clone(), channels.clone());
-      let res = hot_store.get_joins(channel);
+      hot_store.put_join(&channel.clone(), &channels.clone());
+      let res = hot_store.get_joins(&channel);
       assert_eq!(res, vec![channels]);
   }
 
@@ -693,9 +693,9 @@ proptest! {
   fn remove_join_should_remove_join_for_a_channel(channel in  any::<String>(), channels in vec(any::<String>(), 0..=SIZE_RANGE)) {
       let (_, _, hot_store) = fixture();
 
-      hot_store.put_join(channel.clone(), channels.clone());
-      hot_store.remove_join(channel.clone(), channels.clone());
-      let res = hot_store.get_joins(channel);
+      hot_store.put_join(&channel.clone(), &channels.clone());
+      hot_store.remove_join(&channel.clone(), &channels.clone());
+      let res = hot_store.get_joins(&channel);
       assert!(res.is_empty());
   }
 
@@ -703,10 +703,10 @@ proptest! {
   fn remove_join_should_remove_only_passed_in_joins_for_a_channel(channel in  any::<String>(), channels in vec(any::<String>(), 0..=SIZE_RANGE)) {
       let (_, _, hot_store) = fixture();
 
-      hot_store.put_join(channel.clone(), channels.clone());
-      hot_store.put_join(channel.clone(), vec!["other_channel".to_string()]);
-      hot_store.remove_join(channel.clone(), channels.clone());
-      let res = hot_store.get_joins(channel);
+      hot_store.put_join(&channel.clone(), &channels.clone());
+      hot_store.put_join(&channel.clone(), &vec!["other_channel".to_string()]);
+      hot_store.remove_join(&channel.clone(), &channels.clone());
+      let res = hot_store.get_joins(&channel);
       assert_eq!(res, vec![vec!["other_channel".to_string()]]);
   }
 
@@ -728,9 +728,9 @@ proptest! {
       prop_assume!(continuation1 != continuation2);
       let (_, _, hot_store) = fixture();
 
-      hot_store.put_continuation(channels.clone(), continuation1.clone());
+      hot_store.put_continuation(&channels.clone(), continuation1.clone());
       let snapshot = hot_store.snapshot();
-      hot_store.put_continuation(channels.clone(), continuation2.clone());
+      hot_store.put_continuation(&channels.clone(), continuation2.clone());
       assert!(snapshot.continuations.get(&channels).unwrap().clone().contains(&continuation1));
       assert!(!snapshot.continuations.get(&channels).unwrap().clone().contains(&continuation2));
   }
@@ -740,9 +740,9 @@ proptest! {
       prop_assume!(continuation1 != continuation2);
       let (_, _, hot_store) = fixture();
 
-      hot_store.install_continuation(channels.clone(), continuation1.clone());
+      hot_store.install_continuation(&channels.clone(), continuation1.clone());
       let snapshot = hot_store.snapshot();
-      hot_store.install_continuation(channels.clone(), continuation2.clone());
+      hot_store.install_continuation(&channels.clone(), continuation2.clone());
       assert_eq!(snapshot.installed_continuations.get(&channels).unwrap().clone(), continuation1);
   }
 
@@ -751,9 +751,9 @@ proptest! {
       prop_assume!(data1 != data2);
       let (_, _, hot_store) = fixture();
 
-      hot_store.put_datum(channel.clone(), data1.clone());
+      hot_store.put_datum(&channel.clone(), data1.clone());
       let snapshot = hot_store.snapshot();
-      hot_store.put_datum(channel.clone(), data2.clone());
+      hot_store.put_datum(&channel.clone(), data2.clone());
       assert!(!snapshot.data.get(&channel).unwrap().clone().contains(&data2));
   }
 
@@ -762,9 +762,9 @@ proptest! {
       prop_assume!(join1 != join2);
       let (_, _, hot_store) = fixture();
 
-      hot_store.put_join(channel.clone(), join1.clone());
+      hot_store.put_join(&channel.clone(), &join1.clone());
       let snapshot = hot_store.snapshot();
-      hot_store.put_join(channel.clone(), join2.clone());
+      hot_store.put_join(&channel.clone(), &join2.clone());
       assert!(!snapshot.joins.get(&channel).unwrap().clone().contains(&join2));
   }
 
@@ -773,9 +773,9 @@ proptest! {
       prop_assume!(join1 != join2);
       let (_, _, hot_store) = fixture();
 
-      hot_store.install_join(channel.clone(), join1.clone());
+      hot_store.install_join(&channel.clone(), &join1.clone());
       let snapshot = hot_store.snapshot();
-      hot_store.install_join(channel.clone(), join2.clone());
+      hot_store.install_join(&channel.clone(), &join2.clone());
       assert!(snapshot.installed_joins.get(&channel).unwrap().clone().contains(&join1));
       assert!(!snapshot.installed_joins.get(&channel).unwrap().clone().contains(&join2));
   }

--- a/rspace++/tests/storage_actions_test.rs
+++ b/rspace++/tests/storage_actions_test.rs
@@ -129,7 +129,7 @@ async fn produce_should_persist_data_in_store() {
     let data = rspace.store.get_data(&channel);
     assert_eq!(data, vec![Datum::create(&channel, "datum".to_string(), false)]);
 
-    let cont = rspace.store.get_continuations(key);
+    let cont = rspace.store.get_continuations(&key);
     assert_eq!(cont.len(), 0);
     assert!(r.unwrap().is_none());
 
@@ -160,21 +160,18 @@ async fn producing_twice_on_same_channel_should_persist_two_pieces_of_data_in_st
     let d1 = rspace.store.get_data(&channel);
     assert_eq!(d1, vec![Datum::create(&channel, "datum1".to_string(), false)]);
 
-    let wc1 = rspace.store.get_continuations(key.clone());
+    let wc1 = rspace.store.get_continuations(&key.clone());
     assert_eq!(wc1.len(), 0);
     assert!(r1.unwrap().is_none());
 
     let r2 = rspace.produce(key[0].clone(), "datum2".to_string(), false);
     let d2 = rspace.store.get_data(&channel);
-    assert!(check_same_elements(
-        d2,
-        vec![
-            Datum::create(&channel, "datum1".to_string(), false),
-            Datum::create(&channel, "datum2".to_string(), false)
-        ]
-    ));
+    assert!(check_same_elements(d2, vec![
+        Datum::create(&channel, "datum1".to_string(), false),
+        Datum::create(&channel, "datum2".to_string(), false)
+    ]));
 
-    let wc2 = rspace.store.get_continuations(key.clone());
+    let wc2 = rspace.store.get_continuations(&key.clone());
     assert_eq!(wc2.len(), 0);
     assert!(r2.unwrap().is_none());
 
@@ -206,7 +203,7 @@ async fn consuming_on_one_channel_should_persist_continuation_in_store() {
     let d1 = rspace.store.get_data(&channel);
     assert_eq!(d1.len(), 0);
 
-    let c1 = rspace.store.get_continuations(key.clone());
+    let c1 = rspace.store.get_continuations(&key.clone());
     assert_ne!(c1.len(), 0);
     assert!(r.unwrap().is_none());
 
@@ -241,7 +238,7 @@ async fn consuming_on_three_channels_should_persist_continuation_in_store() {
         assert!(seq.is_empty(), "d should be empty");
     }
 
-    let c1 = rspace.store.get_continuations(key);
+    let c1 = rspace.store.get_continuations(&key);
     assert_ne!(c1.len(), 0);
     assert!(r.unwrap().is_none());
 
@@ -266,7 +263,7 @@ async fn producing_then_consuming_on_same_channel_should_return_continuation_and
     let d1 = rspace.store.get_data(&channel);
     assert_eq!(d1, vec![Datum::create(&channel, "datum".to_string(), false)]);
 
-    let c1 = rspace.store.get_continuations(key.clone());
+    let c1 = rspace.store.get_continuations(&key.clone());
     assert_eq!(c1.len(), 0);
     assert!(r1.unwrap().is_none());
 
@@ -280,7 +277,7 @@ async fn producing_then_consuming_on_same_channel_should_return_continuation_and
     let d2 = rspace.store.get_data(&channel);
     assert_eq!(d2.len(), 0);
 
-    let c2 = rspace.store.get_continuations(key);
+    let c2 = rspace.store.get_continuations(&key);
     assert_eq!(c2.len(), 0);
     assert!(r2.clone().unwrap().is_some());
 
@@ -309,7 +306,7 @@ async fn producing_then_consuming_on_same_channel_with_peek_should_return_contin
     let d1 = rspace.store.get_data(&channel);
     assert_eq!(d1, vec![Datum::create(&channel, "datum".to_string(), false)]);
 
-    let c1 = rspace.store.get_continuations(key.clone());
+    let c1 = rspace.store.get_continuations(&key.clone());
     assert_eq!(c1.len(), 0);
     assert!(r1.unwrap().is_none());
 
@@ -323,7 +320,7 @@ async fn producing_then_consuming_on_same_channel_with_peek_should_return_contin
     let d2 = rspace.store.get_data(&channel);
     assert_eq!(d2.len(), 0);
 
-    let c2 = rspace.store.get_continuations(key);
+    let c2 = rspace.store.get_continuations(&key);
     assert_eq!(c2.len(), 0);
     assert!(r2.clone().unwrap().is_some());
 
@@ -356,14 +353,14 @@ async fn consuming_then_producing_on_same_channel_with_peek_should_return_contin
         std::iter::once(0).collect(),
     );
     assert!(r1.unwrap().is_none());
-    let c1 = rspace.store.get_continuations(key.clone());
+    let c1 = rspace.store.get_continuations(&key.clone());
     assert_eq!(c1.len(), 1);
 
     let r2 = rspace.produce(channel.clone(), "datum".to_string(), false);
     let d1 = rspace.store.get_data(&channel);
     assert!(d1.is_empty());
 
-    let c2 = rspace.store.get_continuations(key);
+    let c2 = rspace.store.get_continuations(&key);
     assert_eq!(c2.len(), 0);
     assert!(r2.clone().unwrap().is_some());
 
@@ -396,14 +393,14 @@ async fn consuming_then_producing_on_same_channel_with_persistent_flag_should_re
         BTreeSet::default(),
     );
     assert!(r1.unwrap().is_none());
-    let c1 = rspace.store.get_continuations(key.clone());
+    let c1 = rspace.store.get_continuations(&key.clone());
     assert_eq!(c1.len(), 1);
 
     let r2 = rspace.produce(channel.clone(), "datum".to_string(), true);
     let d1 = rspace.store.get_data(&channel);
     assert!(d1.is_empty());
 
-    let c2 = rspace.store.get_continuations(key);
+    let c2 = rspace.store.get_continuations(&key);
     assert_eq!(c2.len(), 0);
     assert!(r2.clone().unwrap().is_some());
 
@@ -502,7 +499,7 @@ async fn producing_on_channel_then_consuming_on_that_channel_and_another_then_pr
     let d1 = rspace.store.get_data(&produce_key_1[0]);
     assert_eq!(d1, vec![Datum::create(&produce_key_1[0], "datum1".to_string(), false)]);
 
-    let c1 = rspace.store.get_continuations(produce_key_1.clone());
+    let c1 = rspace.store.get_continuations(&produce_key_1.clone());
     assert!(c1.is_empty());
     assert!(r1.unwrap().is_none());
 
@@ -516,16 +513,16 @@ async fn producing_on_channel_then_consuming_on_that_channel_and_another_then_pr
     let d2 = rspace.store.get_data(&produce_key_1[0]);
     assert_eq!(d2, vec![Datum::create(&produce_key_1[0], "datum1".to_string(), false)]);
 
-    let c2 = rspace.store.get_continuations(produce_key_1.clone());
+    let c2 = rspace.store.get_continuations(&produce_key_1.clone());
     let d3 = rspace.store.get_data(&produce_key_2[0]);
-    let c3 = rspace.store.get_continuations(consume_key.clone());
+    let c3 = rspace.store.get_continuations(&consume_key.clone());
     assert!(c2.is_empty());
     assert!(d3.is_empty());
     assert_ne!(c3.len(), 0);
     assert!(r2.unwrap().is_none());
 
     let r3 = rspace.produce(produce_key_2[0].clone(), "datum2".to_string(), false);
-    let c4 = rspace.store.get_continuations(consume_key);
+    let c4 = rspace.store.get_continuations(&consume_key);
     let d4 = rspace.store.get_data(&produce_key_1[0]);
     let d5 = rspace.store.get_data(&produce_key_2[0]);
     assert!(c4.is_empty());
@@ -563,7 +560,7 @@ async fn producing_on_three_channels_then_consuming_once_should_return_cont_and_
     let d1 = rspace.store.get_data(&produce_key_1[0]);
     assert_eq!(d1, vec![Datum::create(&produce_key_1[0], "datum1".to_string(), false)]);
 
-    let c1 = rspace.store.get_continuations(produce_key_1);
+    let c1 = rspace.store.get_continuations(&produce_key_1);
     assert!(c1.is_empty());
     assert!(r1.unwrap().is_none());
 
@@ -571,7 +568,7 @@ async fn producing_on_three_channels_then_consuming_once_should_return_cont_and_
     let d2 = rspace.store.get_data(&produce_key_2[0]);
     assert_eq!(d2, vec![Datum::create(&produce_key_2[0], "datum2".to_string(), false)]);
 
-    let c2 = rspace.store.get_continuations(produce_key_2);
+    let c2 = rspace.store.get_continuations(&produce_key_2);
     assert!(c2.is_empty());
     assert!(r2.unwrap().is_none());
 
@@ -579,7 +576,7 @@ async fn producing_on_three_channels_then_consuming_once_should_return_cont_and_
     let d3 = rspace.store.get_data(&produce_key_3[0]);
     assert_eq!(d3, vec![Datum::create(&produce_key_3[0], "datum3".to_string(), false)]);
 
-    let c3 = rspace.store.get_continuations(produce_key_3);
+    let c3 = rspace.store.get_continuations(&produce_key_3);
     assert!(c3.is_empty());
     assert!(r3.unwrap().is_none());
 
@@ -599,7 +596,7 @@ async fn producing_on_three_channels_then_consuming_once_should_return_cont_and_
         assert!(seq.is_empty(), "d should be empty");
     }
 
-    let c4 = rspace.store.get_continuations(consume_key);
+    let c4 = rspace.store.get_continuations(&consume_key);
     assert!(c4.is_empty());
     assert!(r4.clone().unwrap().is_some());
 
@@ -650,7 +647,7 @@ async fn producing_then_consuming_three_times_on_same_channel_should_return_thre
     );
     let r6 =
         rspace.consume(key.clone(), vec![Pattern::Wildcard], captor, false, BTreeSet::default());
-    let c1 = rspace.store.get_continuations(key);
+    let c1 = rspace.store.get_continuations(&key);
     assert!(c1.is_empty());
 
     let continuations =
@@ -945,11 +942,11 @@ async fn consuming_and_producing_with_non_trivial_matches_should_work() {
 
     let c1 = rspace
         .store
-        .get_continuations(vec!["ch1".to_string(), "ch2".to_string()]);
+        .get_continuations(&vec!["ch1".to_string(), "ch2".to_string()]);
     assert!(!c1.is_empty());
-    let j1 = rspace.store.get_joins("ch1".to_string());
+    let j1 = rspace.store.get_joins(&"ch1".to_string());
     assert_eq!(j1, vec![vec!["ch1".to_string(), "ch2".to_string()]]);
-    let j2 = rspace.store.get_joins("ch2".to_string());
+    let j2 = rspace.store.get_joins(&"ch2".to_string());
     assert_eq!(j2, vec![vec!["ch1".to_string(), "ch2".to_string()]]);
 
     let insert_actions: Vec<InsertAction<_, _, _, _>> =
@@ -1029,11 +1026,11 @@ async fn consuming_on_two_channels_then_consuming_on_one_then_producing_on_both_
 
     let c1 = rspace
         .store
-        .get_continuations(vec!["ch1".to_string(), "ch2".to_string()]);
+        .get_continuations(&vec!["ch1".to_string(), "ch2".to_string()]);
     assert!(!c1.is_empty());
-    let c2 = rspace.store.get_continuations(vec!["ch1".to_string()]);
+    let c2 = rspace.store.get_continuations(&vec!["ch1".to_string()]);
     assert!((c2.is_empty()));
-    let c3 = rspace.store.get_continuations(vec!["ch2".to_string()]);
+    let c3 = rspace.store.get_continuations(&vec!["ch2".to_string()]);
     assert!(c3.is_empty());
 
     let d1 = rspace.store.get_data(&"ch1".to_string());
@@ -1045,9 +1042,9 @@ async fn consuming_on_two_channels_then_consuming_on_one_then_producing_on_both_
     assert!(r4.unwrap().is_none());
     assert!(check_same_elements(run_produce_k(r3.unwrap()), vec![vec!["datum1".to_string()]]));
 
-    let j1 = rspace.store.get_joins("ch1".to_string());
+    let j1 = rspace.store.get_joins(&"ch1".to_string());
     assert_eq!(j1, vec![vec!["ch1".to_string(), "ch2".to_string()]]);
-    let j2 = rspace.store.get_joins("ch2".to_string());
+    let j2 = rspace.store.get_joins(&"ch2".to_string());
     assert_eq!(j2, vec![vec!["ch1".to_string(), "ch2".to_string()]]);
 
     let insert_actions: Vec<InsertAction<_, _, _, _>> =
@@ -1071,7 +1068,7 @@ async fn producing_then_persistent_consume_on_same_channel_should_return_cont_an
     let r1 = rspace.produce(key[0].clone(), "datum".to_string(), false);
     let d1 = rspace.store.get_data(&key[0]);
     assert_eq!(d1, vec![Datum::create(&key[0], "datum".to_string(), false)]);
-    let c1 = rspace.store.get_continuations(key.clone());
+    let c1 = rspace.store.get_continuations(&key.clone());
     assert!(c1.is_empty());
     assert!(r1.unwrap().is_none());
 
@@ -1105,7 +1102,7 @@ async fn producing_then_persistent_consume_on_same_channel_should_return_cont_an
     );
     let d2 = rspace.store.get_data(&key[0]);
     assert!(d2.is_empty());
-    let c2 = rspace.store.get_continuations(key);
+    let c2 = rspace.store.get_continuations(&key);
     assert!(!c2.is_empty());
     assert!(r3.unwrap().is_none());
 }
@@ -1119,7 +1116,7 @@ async fn producing_then_persistent_consume_then_producing_again_on_same_channel_
     let r1 = rspace.produce(key[0].clone(), "datum1".to_string(), false);
     let d1 = rspace.store.get_data(&key[0]);
     assert_eq!(d1, vec![Datum::create(&key[0], "datum1".to_string(), false)]);
-    let c1 = rspace.store.get_continuations(key.clone());
+    let c1 = rspace.store.get_continuations(&key.clone());
     assert!(c1.is_empty());
     assert!(r1.unwrap().is_none());
 
@@ -1154,14 +1151,14 @@ async fn producing_then_persistent_consume_then_producing_again_on_same_channel_
 
     let d2 = rspace.store.get_data(&key[0]);
     assert!(d2.is_empty());
-    let c2 = rspace.store.get_continuations(key.clone());
+    let c2 = rspace.store.get_continuations(&key.clone());
     assert!(!c2.is_empty());
 
     let r4 = rspace.produce(key[0].clone(), "datum2".to_string(), false);
     assert!(r4.clone().unwrap().is_some());
     let d3 = rspace.store.get_data(&key[0]);
     assert!(d3.is_empty());
-    let c3 = rspace.store.get_continuations(key);
+    let c3 = rspace.store.get_continuations(&key);
     assert!(!c3.is_empty());
     assert!(check_same_elements(
         run_produce_k(r4.clone().unwrap()),
@@ -1182,14 +1179,14 @@ async fn doing_persistent_consume_and_producing_multiple_times_should_work() {
     );
     let d1 = rspace.store.get_data(&"ch1".to_string());
     assert!(d1.is_empty());
-    let c1 = rspace.store.get_continuations(vec!["ch1".to_string()]);
+    let c1 = rspace.store.get_continuations(&vec!["ch1".to_string()]);
     assert!(!c1.is_empty());
     assert!(r1.unwrap().is_none());
 
     let r2 = rspace.produce("ch1".to_string(), "datum1".to_string(), false);
     let d2 = rspace.store.get_data(&"ch1".to_string());
     assert!(d2.is_empty());
-    let c2 = rspace.store.get_continuations(vec!["ch1".to_string()]);
+    let c2 = rspace.store.get_continuations(&vec!["ch1".to_string()]);
     assert!(!c2.is_empty());
     assert!(r2.clone().unwrap().is_some());
     assert!(check_same_elements(
@@ -1200,7 +1197,7 @@ async fn doing_persistent_consume_and_producing_multiple_times_should_work() {
     let r3 = rspace.produce("ch1".to_string(), "datum2".to_string(), false);
     let d3 = rspace.store.get_data(&"ch1".to_string());
     assert!(d3.is_empty());
-    let c3 = rspace.store.get_continuations(vec!["ch1".to_string()]);
+    let c3 = rspace.store.get_continuations(&vec!["ch1".to_string()]);
     assert!(!c3.is_empty());
     assert!(r3.clone().unwrap().is_some());
 
@@ -1251,7 +1248,7 @@ async fn consuming_and_doing_persistent_produce_should_work() {
     assert!(r3.unwrap().is_none());
     let d1 = rspace.store.get_data(&"ch1".to_string());
     assert_eq!(d1, vec![Datum::create(&"ch1".to_string(), "datum1".to_string(), true)]);
-    let c1 = rspace.store.get_continuations(vec!["ch1".to_string()]);
+    let c1 = rspace.store.get_continuations(&vec!["ch1".to_string()]);
     assert!(c1.is_empty());
 }
 
@@ -1286,7 +1283,7 @@ async fn consuming_then_persistent_produce_then_consuming_should_work() {
     assert!(r3.unwrap().is_none());
     let d1 = rspace.store.get_data(&"ch1".to_string());
     assert_eq!(d1, vec![Datum::create(&"ch1".to_string(), "datum1".to_string(), true)]);
-    let c1 = rspace.store.get_continuations(vec!["ch1".to_string()]);
+    let c1 = rspace.store.get_continuations(&vec!["ch1".to_string()]);
     assert!(c1.is_empty());
 
     let r4 = rspace.consume(
@@ -1299,7 +1296,7 @@ async fn consuming_then_persistent_produce_then_consuming_should_work() {
     assert!(r4.clone().unwrap().is_some());
     let d2 = rspace.store.get_data(&"ch1".to_string());
     assert_eq!(d2, vec![Datum::create(&"ch1".to_string(), "datum1".to_string(), true)]);
-    let c2 = rspace.store.get_continuations(vec!["ch1".to_string()]);
+    let c2 = rspace.store.get_continuations(&vec!["ch1".to_string()]);
     assert!(c2.is_empty());
     assert!(check_same_elements(run_k(r4.unwrap()), vec![vec!["datum1".to_string()]]))
 }
@@ -1311,7 +1308,7 @@ async fn doing_persistent_produce_and_consuming_twice_should_work() {
     let r1 = rspace.produce("ch1".to_string(), "datum1".to_string(), true);
     let d1 = rspace.store.get_data(&"ch1".to_string());
     assert_eq!(d1, vec![Datum::create(&"ch1".to_string(), "datum1".to_string(), true)]);
-    let c1 = rspace.store.get_continuations(vec!["ch1".to_string()]);
+    let c1 = rspace.store.get_continuations(&vec!["ch1".to_string()]);
     assert!(c1.is_empty());
     assert!(r1.unwrap().is_none());
 
@@ -1324,7 +1321,7 @@ async fn doing_persistent_produce_and_consuming_twice_should_work() {
     );
     let d2 = rspace.store.get_data(&"ch1".to_string());
     assert_eq!(d2, vec![Datum::create(&"ch1".to_string(), "datum1".to_string(), true)]);
-    let c2 = rspace.store.get_continuations(vec!["ch1".to_string()]);
+    let c2 = rspace.store.get_continuations(&vec!["ch1".to_string()]);
     assert!(c2.is_empty());
     assert!(r2.clone().unwrap().is_some());
     assert!(check_same_elements(run_k(r2.unwrap()), vec![vec!["datum1".to_string()]]));
@@ -1338,7 +1335,7 @@ async fn doing_persistent_produce_and_consuming_twice_should_work() {
     );
     let d3 = rspace.store.get_data(&"ch1".to_string());
     assert_eq!(d3, vec![Datum::create(&"ch1".to_string(), "datum1".to_string(), true)]);
-    let c3 = rspace.store.get_continuations(vec!["ch1".to_string()]);
+    let c3 = rspace.store.get_continuations(&vec!["ch1".to_string()]);
     assert!(c3.is_empty());
     assert!(r3.clone().unwrap().is_some());
     assert!(check_same_elements(run_k(r3.unwrap()), vec![vec!["datum1".to_string()]]));
@@ -1371,7 +1368,7 @@ async fn producing_three_times_then_doing_persistent_consume_should_work() {
     );
     let d1 = rspace.store.get_data(&"ch1".to_string());
     assert!(expected_data.iter().any(|datum| d1.contains(datum)));
-    let c1 = rspace.store.get_continuations(vec!["ch1".to_string()]);
+    let c1 = rspace.store.get_continuations(&vec!["ch1".to_string()]);
     assert!(c1.is_empty());
     assert!(r4.clone().unwrap().is_some());
     let cont_results_r4 = run_k(r4.unwrap());
@@ -1390,7 +1387,7 @@ async fn producing_three_times_then_doing_persistent_consume_should_work() {
     );
     let d2 = rspace.store.get_data(&"ch1".to_string());
     assert!(expected_data.iter().any(|datum| d2.contains(datum)));
-    let c2 = rspace.store.get_continuations(vec!["ch1".to_string()]);
+    let c2 = rspace.store.get_continuations(&vec!["ch1".to_string()]);
     assert!(c2.is_empty());
     assert!(r5.clone().unwrap().is_some());
     let cont_results_r5 = run_k(r5.unwrap());
@@ -1435,7 +1432,7 @@ async fn producing_three_times_then_doing_persistent_consume_should_work() {
     );
     let d3 = rspace.store.get_data(&"ch1".to_string());
     assert!(d3.is_empty());
-    let c3 = rspace.store.get_continuations(vec!["ch1".to_string()]);
+    let c3 = rspace.store.get_continuations(&vec!["ch1".to_string()]);
     assert!(!c3.is_empty());
     assert!(r7.unwrap().is_none());
 }


### PR DESCRIPTION
This change improves memory efficiency and consistency in the handling of channels and continuations in the RSpace and interpreter modules.

