### PR TITLE
Impl Abort System process

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -285,10 +285,17 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
       // No errors
       case Vector() => ifNoError.pure[M]
 
-      // Out Of Phlogiston error is always single
-      // - if one execution path is out of phlo, the whole evaluation is also
-      case errList if errList.contains(OutOfPhlogistonsError) =>
-        OutOfPhlogistonsError.raiseError[M, R]
+      // Out Of Phlogiston or User Abort error is always single
+      // - if one execution path hits these, the whole evaluation stops as well
+      case errList if errList.exists {
+            case OutOfPhlogistonsError => true
+            case UserAbortError        => true
+            case _                     => false
+          } =>
+        if (errList.contains(UserAbortError))
+          UserAbortError.raiseError[M, R]
+        else
+          OutOfPhlogistonsError.raiseError[M, R]
 
       // Rethrow single error
       case Vector(ex) =>

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoRuntime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoRuntime.scala
@@ -318,6 +318,10 @@ object RhoRuntime {
       ctx: ProcessContext[F] =>
         ctx.systemProcesses.stdErrAck
     }),
+    Definition[F]("rho:execution:abort", FixedChannels.ABORT, 1, BodyRefs.ABORT, {
+      ctx: ProcessContext[F] =>
+        ctx.systemProcesses.abort
+    }),
     Definition[F](
       "rho:io:grpcTell",
       FixedChannels.GRPC_TELL,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
@@ -64,6 +64,8 @@ object errors {
   final case object OutOfPhlogistonsError
       extends InterpreterError("Computation ran out of phlogistons.")
 
+  final case object UserAbortError extends InterpreterError("Computation aborted by user request.")
+
   final case class TopLevelWildcardsNotAllowedError(wildcards: String)
       extends InterpreterError(s"Top level wildcards are not allowed: $wildcards.")
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/AbortSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/AbortSpec.scala
@@ -1,0 +1,43 @@
+package coop.rchain.rholang.interpreter
+
+import coop.rchain.metrics
+import coop.rchain.metrics.{Metrics, NoopSpan, Span}
+import coop.rchain.rholang.Resources.mkRuntime
+import coop.rchain.rholang.interpreter.errors.UserAbortError
+import coop.rchain.rholang.syntax._
+import coop.rchain.shared.Log
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.duration._
+
+class AbortSpec extends FlatSpec with Matchers {
+  private val tmpPrefix                   = "abort-spec-store-"
+  private val maxDuration                 = 5.seconds
+  implicit val logF: Log[Task]            = Log.log[Task]
+  implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
+  implicit val noopSpan: Span[Task]       = NoopSpan[Task]()
+
+  "rho:execution:abort" should "execute successfully when called with arguments" in {
+    val rhoCode =
+      """
+        |new abort(`rho:execution:abort`) in {
+        |  abort!("Test abort")
+        |}
+        |""".stripMargin
+
+    val result = execute(rhoCode)
+    // Abort should result in UserAbortError and mark execution as failed
+    result.errors should contain(UserAbortError)
+    result.cost.value should be(316L +- 100L)
+    result.succeeded should be(false)
+  }
+
+  private def execute(source: String): EvaluateResult =
+    mkRuntime[Task](tmpPrefix)
+      .use { runtime =>
+        runtime.evaluate(source)
+      }
+      .runSyncUnsafe(maxDuration)
+}


### PR DESCRIPTION
# Changes
- Introduced UserAbortError to handle user-triggered computation aborts.
- Updated Interpreter and Reduce classes to propagate UserAbortError appropriately.
- Added a new abort system process to allow explicit termination of Rholang computations.
- Enhanced error handling to include both OutOfPhlogistonsError and UserAbortError in evaluation logic.

# Tests
## Unit tests
Added a unit test to verify it abort the deploy 

## Manual test
1. Make 2 deploys
2. Hit Propose 
3. Get the block info and check the deploy with 'abort' was errored and another get passed:
<img width="1353" height="675" alt="image" src="https://github.com/user-attachments/assets/696532df-5f27-428e-b6c5-79a31eb8af61" />