### PR TITLE
fix: replace hardcoded bootstrap address with configurable default

### DIFF
--- a/docker/shard-with-autopropose.yml
+++ b/docker/shard-with-autopropose.yml
@@ -16,6 +16,7 @@ services:
         "-Dlogback.configurationFile=/var/lib/rnode/logback.xml",
         "run",
         "--host=$BOOTSTRAP_HOST",
+        "--bootstrap=rnode://$BOOTSTRAP_NODE_ID@$BOOTSTRAP_HOST?protocol=40400&discovery=40404", # node will know it's bootstrap node
         "--allow-private-addresses",
         "--validator-private-key=$BOOTSTRAP_PRIVATE_KEY"
       ]

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -67,7 +67,9 @@ protocol-client {
   # To manually generate one the following command can be used
   # ```openssl ec -text -in <path-to-tls-key>/node.key.pem | grep pub -A 5 | tail -n +2 | tr -d '\n[:space:]:' | \
   # sed 's/^04//' | keccak-256sum -x -l | tr -d ' -' | tail -c 41```
-  bootstrap = "rnode://de6eed5d00cf080fc587eeb412cb31a75fd10358@52.119.8.109?protocol=40400&discovery=40404"
+  # Example placeholder (replace with your shard's bootstrap address):
+  # rnode://<node-id>@<host>?protocol=<protocol-port>&discovery=<discovery-port>
+  bootstrap = "rnode://0000000000000000000000000000000000000000@127.0.0.1?protocol=40400&discovery=40404"
 
   # Disable the node to start from Last Finalized State, instead it will start from genesis.
   # If this is `true`, when a node without any data connecting to existing network, the node would start from

--- a/node/src/main/scala/coop/rchain/node/runtime/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/NodeRuntime.scala
@@ -256,9 +256,12 @@ class NodeRuntime[F[_]: Monixable: ConcurrentEffect: Parallel: Timer: ContextShi
     val standaloneInfo: F[Unit] =
       if (nodeConf.standalone) Log[F].info(s"Starting stand-alone node.")
       else
-        Log[F].info(
-          s"Starting node that will bootstrap from ${nodeConf.protocolClient.bootstrap}"
-        )
+        peerNodeAsk.ask.flatMap { local =>
+          if (local == nodeConf.protocolClient.bootstrap)
+            Log[F].info(s"Starting bootstrap seed node.")
+          else
+            Log[F].info(s"Starting node. Bootstrapping from ${nodeConf.protocolClient.bootstrap}")
+        }
 
     val rspaceInfo: F[Unit] =
       if (nodeConf.rspacePlusPlus) Log[F].info(s"Starting node using rspace++.")


### PR DESCRIPTION
- Replace hardcoded bootstrap address in defaults.conf with placeholder
- Add bootstrap node detection logic to distinguish bootstrap vs regular nodes
- Update docker config to properly set bootstrap address from environment
