### PR TITLE
add Prometheus and Grafana monitoring stack for Shard in Docker Compose

### DIFF
--- a/docker/conf/bootstrap-ceremony.conf
+++ b/docker/conf/bootstrap-ceremony.conf
@@ -373,7 +373,7 @@ casper {
 
 # Enable/disable Kamon reporters. Kamon is used for metrics collection / aggregation.
 metrics {
-  prometheus = false
+  prometheus = true
   # Enable default influxdb reporter
   influxdb = false
   # Our requirement is to send metrics every 500ms to InfluxDB. The default `kamon-influxdb` uses HTTP with a

--- a/docker/conf/shared-rnode-runtime.conf
+++ b/docker/conf/shared-rnode-runtime.conf
@@ -370,7 +370,7 @@ casper {
 
 # Enable/disable Kamon reporters. Kamon is used for metrics collection / aggregation.
 metrics {
-  prometheus = false
+  prometheus = true
   # Enable default influxdb reporter
   influxdb = false
   # Our requirement is to send metrics every 500ms to InfluxDB. The default `kamon-influxdb` uses HTTP with a

--- a/docker/conf/shared-rnode.conf
+++ b/docker/conf/shared-rnode.conf
@@ -370,7 +370,7 @@ casper {
 
 # Enable/disable Kamon reporters. Kamon is used for metrics collection / aggregation.
 metrics {
-  prometheus = false
+  prometheus = true
   # Enable default influxdb reporter
   influxdb = false
   # Our requirement is to send metrics every 500ms to InfluxDB. The default `kamon-influxdb` uses HTTP with a

--- a/docker/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/docker/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+

--- a/docker/monitoring/prometheus.yml
+++ b/docker/monitoring/prometheus.yml
@@ -1,0 +1,24 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'validators'
+    metrics_path: /metrics
+    scheme: http
+    static_configs:
+      - targets:
+          - validator1:40403
+          - validator2:40403
+          - validator3:40403
+    relabel_configs:
+      - source_labels: [__address__]
+        regex: "([^:]+):.*"
+        target_label: instance
+        replacement: "$1"
+
+  - job_name: 'bootstrap'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['boot:40403']
+

--- a/docker/prometheus-grafana.md
+++ b/docker/prometheus-grafana.md
@@ -1,0 +1,55 @@
+# Installing Grafana and Prometheus
+
+## Prerequisites
+
+- A running F1r3fly cluster
+
+## Installation (Docker Compose extension for shard)
+
+If you are running the shard with `docker/shard-with-autopropose.yml`, you can bring up Prometheus and Grafana on the same network and have Prometheus scrape all validators automatically.
+
+1. Start/ensure your shard is running
+```bash
+docker compose -f docker/shard-with-autopropose.yml up -d
+```
+
+2. Start monitoring stack (uses the same Docker network as the shard)
+```bash
+docker compose -f docker/shard-with-autopropose.yml -f docker/shard-monitoring.yml up -d
+```
+
+This will:
+- Enable Prometheus scraping of `boot`, `validator1`, `validator2`, `validator3` at `http://<node>:40403/metrics`
+- Start Prometheus on localhost:9090
+- Start Grafana on localhost:3000 with a pre-provisioned Prometheus datasource
+
+3. Access UIs
+```bash
+open http://localhost:9090   # Prometheus
+open http://localhost:3000   # Grafana (default user: admin / password: admin)
+```
+
+Note: Grafana default credentials are `admin` / `admin`. You may be prompted to change the password on first login.
+
+
+## Generate and import a Grafana dashboard
+
+1. Generate dashboard JSON from a node's metrics endpoint (pick any node):
+```bash
+# Example: bootstrap node exposes 40403 on localhost
+../scripts/rnode-metric-counters-to-grafana-dash.sh http://127.0.0.1:40403/metrics > ../target/grafana.json
+```
+
+2. Import into Grafana:
+   - Open http://localhost:3000
+   - Left sidebar: “+” → “Import”
+   - Click “Upload JSON file” and select `../target/grafana.json`
+   - Ensure the Prometheus datasource is set to `Prometheus`
+   - Click “Import”
+
+## Uninstall
+
+Docker Compose:
+```sh
+docker compose -f docker/shard-monitoring.yml down
+```

--- a/docker/shard-monitoring.yml
+++ b/docker/shard-monitoring.yml
@@ -1,0 +1,36 @@
+version: "3.8"
+
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: unless-stopped
+    networks:
+      - docker_f1r3fly
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+    networks:
+      - docker_f1r3fly
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_USERS_DEFAULT_THEME=light
+      - GF_INSTALL_PLUGINS=grafana-piechart-panel
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+
+
+networks:
+  docker_f1r3fly:
+    external: true


### PR DESCRIPTION
# Changes
- Introduced new configuration files for Prometheus and Grafana.
- Updated bootstrap ceremony and shared runtime configurations to enable Prometheus metrics.
- Added a script for generating Grafana dashboards from Prometheus metrics.
- Included instructions for installation and usage in the new documentation file.

## Prometheus metrics reference (compiled from Local run)

Descriptions of metrics present in `promtheus-metrics-example.txt`, grouped by subsystem.

### comm (network)

| Metric | Type | Description |
|---|---|---|
| `rchain_comm_discovery_kademlia_grpc_protocol_lookup_send_total` | counter | Number of Kademlia lookup RPCs sent to peers. |
| `rchain_comm_discovery_kademlia_handle_lookup_total` | counter | Number of incoming Kademlia lookup requests handled. |
| `rchain_comm_discovery_kademlia_grpc_lookup_time_seconds` | histogram | Latency of Kademlia gRPC lookup operations (seconds). |
| `rchain_comm_discovery_kademlia_peers` | gauge | Number of peers discovered via Kademlia. |
| `rchain_comm_rp_connect_connect_total` | counter | Total peer connection attempts initiated. |
| `rchain_comm_rp_connect_connect_time_seconds` | histogram | Time to establish peer connections (seconds). |
| `rchain_comm_rp_connect_peers` | gauge | Current number of connected peers. |
| `rchain_comm_rp_transport_send_total` | counter | Total transport send operations performed. |
| `rchain_comm_rp_transport_send_time_seconds` | histogram | Latency of transport send operations (seconds). |
| `rchain_comm_rp_transport_packets_enqueued_total` | counter | Number of packets enqueued for sending. |
| `rchain_comm_rp_transport_dispatched_packets_total` | counter | Number of packets dispatched by transport. |
| `rchain_comm_rp_transport_packets_received_total` | counter | Number of packets received by transport. |
| `rchain_comm_rp_transport_dispatched_messages_total` | counter | Number of messages dispatched by transport. |
| `rchain_comm_rp_transport_stream_chunks_enqueued_total` | counter | Number of stream chunks enqueued for sending. |
| `rchain_comm_rp_transport_stream_chunks_received_total` | counter | Number of stream chunks received on transport. |

### rspace (runtime storage)

| Metric | Type | Description |
|---|---|---|
| `rchain_rspace_comm_produce_total` | counter | Total number of produce events (writes) in RSpace. |
| `rchain_rspace_comm_consume_total` | counter | Total number of consume events (reads/matches) in RSpace. |
| `rchain_rspace_comm_produce_time_seconds` | histogram | Latency of produce operations (seconds). |
| `rchain_rspace_comm_consume_time_seconds` | histogram | Latency of consume operations (seconds). |
| `rchain_rspace_install_time_seconds` | histogram | Time to install patterns/continuations into RSpace (seconds). |
| `rchain_rspace_two_step_lock_phase_a_lock_acquire_seconds` | histogram | Time to acquire internal RSpace lock (phase A) (seconds). |
| `rchain_rspace_two_step_lock_phase_b_lock_acquire_seconds` | histogram | Time to acquire internal RSpace lock (phase B) (seconds). |
| `rchain_rspace_two_step_lock_phase_a_lock_queue` | gauge | Queue length waiting for RSpace lock (phase A). |
| `rchain_rspace_two_step_lock_phase_b_lock_queue` | gauge | Queue length waiting for RSpace lock (phase B). |

### rspace (replay)

| Metric | Type | Description |
|---|---|---|
| `rchain_rspace_replay_comm_produce_total` | counter | Total number of produce events during replay. |
| `rchain_rspace_replay_comm_consume_total` | counter | Total number of consume events during replay. |
| `rchain_rspace_replay_comm_produce_time_seconds` | histogram | Latency of produce operations during replay (seconds). |
| `rchain_rspace_replay_comm_consume_time_seconds` | histogram | Latency of consume operations during replay (seconds). |
| `rchain_rspace_replay_install_time_seconds` | histogram | Time to install patterns/continuations during replay (seconds). |
| `rchain_rspace_replay_two_step_lock_phase_a_lock_acquire_seconds` | histogram | Time to acquire replay lock (phase A) (seconds). |
| `rchain_rspace_replay_two_step_lock_phase_b_lock_acquire_seconds` | histogram | Time to acquire replay lock (phase B) (seconds). |
| `rchain_rspace_replay_two_step_lock_phase_a_lock_queue` | gauge | Queue length waiting for replay lock (phase A). |
| `rchain_rspace_replay_two_step_lock_phase_b_lock_queue` | gauge | Queue length waiting for replay lock (phase B). |

### rholang runtime

| Metric | Type | Description |
|---|---|---|
| `rchain_rholang_runtime_lock_acquire_seconds` | histogram | Time to acquire the Rholang runtime lock (seconds). |
| `rchain_rholang_runtime_lock_queue` | gauge | Number of waiters queued for the Rholang runtime lock. |
| `rchain_rholang_runtime_lock_permit` | gauge | Available permits/state for the Rholang runtime lock. |

### block storage

| Metric | Type | Description |
|---|---|---|
| `rchain_block_storage_dag_key_value_store_lock_acquire_seconds` | histogram | Time to acquire DAG key-value store lock (seconds). |
| `rchain_block_storage_dag_key_value_store_lock_queue` | gauge | Queue length waiting for DAG key-value store lock. |
| `rchain_block_storage_dag_key_value_store_lock_permit` | gauge | Available permits/state for DAG key-value store lock. |


# Local run
<img width="1594" height="821" alt="image" src="https://github.com/user-attachments/assets/70f6af95-e5d3-422d-b675-0cd2bf1d8497" />
