### PR TITLE
BUGFIX: Builds and pushes arm64 Docker image as part of the CI

### DIFF
--- a/.github/workflows/optional-workflow.yml
+++ b/.github/workflows/optional-workflow.yml
@@ -164,12 +164,14 @@ jobs:
         with:
           workflow: required-workflow.yml
           run_id: ${{ github.event.workflow_run.id }}
-          name: artifacts-docker
+          name: artifacts-docker-amd64
           path: /tmp
 
       - name: Import Docker Image
         shell: bash -ex {0}
-        run: zcat /tmp/rnode-docker.tar.gz | docker image load
+        run: |
+          zcat /tmp/rnode-docker.tar.gz | docker image load
+          docker tag f1r3flyindustries/f1r3fly-scala-node:amd64 f1r3flyindustries/f1r3fly-scala-node
 
       - name: Run Integration Test
         env:

--- a/.github/workflows/optional-workflow.yml
+++ b/.github/workflows/optional-workflow.yml
@@ -83,6 +83,71 @@ jobs:
         shell: bash -ex {0}
         run: .github/run-unit-test-selection
 
+  arm64_required_scala_unit_tests:
+    name: ARM64 Required Unit Tests (Scala)
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-22.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        tests:
+          - "'casper/test:testOnly coop.rchain.casper.addblock.*'"
+          - "'casper/test:testOnly coop.rchain.casper.api.*'"
+          - "'casper/test:testOnly coop.rchain.casper.batch1.*'"
+          - "'casper/test:testOnly coop.rchain.casper.engine.*'"
+          - "'casper/test:testOnly coop.rchain.casper.genesis.*'"
+          - "'casper/test:testOnly coop.rchain.casper.merging.*'"
+          - "'casper/test:testOnly coop.rchain.casper.util.*'"
+          - "'node/test:testOnly coop.rchain.node.api.LspServiceSpec'"
+          - "'rholang/test:testOnly coop.rchain.rholang.*'"
+          - "'rspace/test:testOnly coop.rchain.rspace.*'"
+          - "'shared/test:testOnly coop.rchain.shared.*'"
+          - "'crypto/test:testOnly coop.rchain.crypto.*'"
+          - "'comm/test:testOnly coop.rchain.comm.*'"
+          - "'blockStorage/test:testOnly coop.rchain.blockstorage.*'"
+          - "'models/test:testOnly coop.rchain.models.*'"
+    env:
+      TESTS: ${{ matrix.tests }}
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "17"
+          cache: "sbt"
+
+      - name: Add SBT APT repositories
+        shell: bash -ex {0}
+        run: |
+          # https://www.scala-sbt.org/1.x/docs/Installing-sbt-on-Linux.html#Ubuntu+and+other+Debian-based+distributions
+          echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
+          echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
+          curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+
+      - name: Install APT Dependencies
+        shell: bash -ex {0}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y $(cat .github/apt-dependencies.txt)
+
+      - name: Download rchain-worktree Artifact
+        uses: dawidd6/action-download-artifact@v11
+        with:
+          workflow: required-workflow.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: rchain-worktree
+          path: /tmp
+
+      - name: Restore Working Tree
+        shell: bash -ex {0}
+        run: tar -H posix -xzf /tmp/rchain-worktree.tar.gz
+
+      - name: Run Unit Tests
+        shell: bash -ex {0}
+        run: .github/run-unit-test-selection
+
   optional_integration_tests:
     name: Optional Integration Tests
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
@@ -182,6 +247,97 @@ jobs:
         run: |
           zcat /tmp/rnode-docker.tar.gz | docker image load
           docker tag f1r3flyindustries/f1r3fly-scala-node:${{ matrix.config.arch }} f1r3flyindustries/f1r3fly-scala-node
+
+      - name: Run Integration Test
+        env:
+          PYTEST_ADDOPTS: -v
+        shell: bash -ex {0}
+        run: |
+          pushd integration-tests
+          pipenv run ../.github/run-integration-test-selection
+          popd
+
+  arm64_required_integration_tests:
+    name: ARM64 Required Integration Tests
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-22.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        tests:
+          - test_backward_compatible
+          - test_genesis_ceremony
+          - test_storage
+          - test_wallets
+          - test_healthcheck
+    env:
+      TESTS: ${{ matrix.tests }}
+      ARCH: arm64
+      # In integration tests multiple RNode instances are created so memory
+      # limit in lower to prevent sporadic crashes.
+      _JAVA_OPTIONS: -XX:MaxRAMPercentage=35.0
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "17"
+          cache: "sbt"
+
+      - name: Add SBT APT repositories
+        shell: bash -ex {0}
+        run: |
+          # https://www.scala-sbt.org/1.x/docs/Installing-sbt-on-Linux.html#Ubuntu+and+other+Debian-based+distributions
+          echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
+          echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
+          curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+
+      - name: Install APT Dependencies
+        shell: bash -ex {0}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y $(cat .github/apt-dependencies.txt)
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.7.17"
+          cache: "pip"
+
+      - name: Install Python dependencies
+        shell: bash -ex {0}
+        run: |
+          pip install pipenv
+          pushd integration-tests
+          pipenv sync
+          popd
+
+      - name: Enable Containerd Image Store
+        shell: bash -ex {0}
+        run: |
+          sudo mkdir -p /etc/docker
+          echo '{"features": {"containerd-snapshotter": true}}' | sudo tee /etc/docker/daemon.json | jq
+          sudo systemctl restart docker
+
+      - name: Set up QEMU for multi-platform emulation
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Download artifacts-docker Artifact
+        uses: dawidd6/action-download-artifact@v11
+        with:
+          workflow: required-workflow.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: artifacts-docker-${{ env.ARCH }}
+          path: /tmp
+
+      - name: Import Docker Image
+        shell: bash -ex {0}
+        run: |
+          zcat /tmp/rnode-docker.tar.gz | docker image load
+          docker tag f1r3flyindustries/f1r3fly-scala-node:${{ env.ARCH }} f1r3flyindustries/f1r3fly-scala-node
 
       - name: Run Integration Test
         env:

--- a/.github/workflows/optional-workflow.yml
+++ b/.github/workflows/optional-workflow.yml
@@ -25,9 +25,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - runner: ubuntu-latest
+          - runner: ubuntu-22.04
             arch: amd64
-          - runner: ubuntu-24.04-arm
+          - runner: ubuntu-22.04-arm
             arch: arm64
         # This runs unit tests in parallel.
         #
@@ -91,9 +91,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - runner: ubuntu-latest
+          - runner: ubuntu-22.04
             arch: amd64
-          - runner: ubuntu-24.04-arm
+          - runner: ubuntu-22.04-arm
             arch: arm64
         # This runs integration tests in parallel.
         #

--- a/.github/workflows/optional-workflow.yml
+++ b/.github/workflows/optional-workflow.yml
@@ -20,10 +20,15 @@ jobs:
   optional_scala_unit_tests:
     name: Optional Unit Tests (Scala)
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.config.runner }}
     strategy:
       fail-fast: false
       matrix:
+        config:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
         # This runs unit tests in parallel.
         #
         # For each entry a runner node is spawned with entry value in
@@ -81,10 +86,15 @@ jobs:
   optional_integration_tests:
     name: Optional Integration Tests
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.config.runner }}
     strategy:
       fail-fast: false
       matrix:
+        config:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
         # This runs integration tests in parallel.
         #
         # For each entry a runner node is spawned with entry value in
@@ -164,14 +174,14 @@ jobs:
         with:
           workflow: required-workflow.yml
           run_id: ${{ github.event.workflow_run.id }}
-          name: artifacts-docker-amd64
+          name: artifacts-docker-${{ matrix.config.arch }}
           path: /tmp
 
       - name: Import Docker Image
         shell: bash -ex {0}
         run: |
           zcat /tmp/rnode-docker.tar.gz | docker image load
-          docker tag f1r3flyindustries/f1r3fly-scala-node:amd64 f1r3flyindustries/f1r3fly-scala-node
+          docker tag f1r3flyindustries/f1r3fly-scala-node:${{ matrix.config.arch }} f1r3flyindustries/f1r3fly-scala-node
 
       - name: Run Integration Test
         env:

--- a/.github/workflows/required-workflow.yml
+++ b/.github/workflows/required-workflow.yml
@@ -509,7 +509,7 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Publish Docker Image
@@ -519,12 +519,12 @@ jobs:
           DEV_LATEST_TAG: ${{ needs.build_base.outputs.DEV_LATEST_TAG }}
         shell: bash -exu -o pipefail {0}
         run: |
-          if [[ -z "${{ secrets.LEGACY_DOCKER_IMAGE_NAME }}" ]]; then
+          if [[ -z "${{ vars.LEGACY_DOCKER_IMAGE_NAME }}" ]]; then
             echo "Required variable \$TARGET_DOCKER_IMAGE_NAME is not set." >&2
             exit 1
           fi
 
-          TARGET_DOCKER_IMAGE_NAME=${{ secrets.LEGACY_DOCKER_IMAGE_NAME }}
+          TARGET_DOCKER_IMAGE_NAME=${{ vars.LEGACY_DOCKER_IMAGE_NAME }}
           SOURCE_DOCKER_IMAGE_NAME_AMD64=f1r3flyindustries/f1r3fly-scala-node:amd64
           SOURCE_DOCKER_IMAGE_NAME_ARM64=f1r3flyindustries/f1r3fly-scala-node:arm64
 

--- a/.github/workflows/required-workflow.yml
+++ b/.github/workflows/required-workflow.yml
@@ -147,10 +147,15 @@ jobs:
   required_scala_unit_tests:
     name: Required Unit Tests (Scala)
     needs: build_base
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.config.runner }}
     strategy:
       fail-fast: false
       matrix:
+        config:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
         # This runs unit tests in parallel.
         #
         # For each entry a runner node is spawned with entry value in
@@ -388,10 +393,15 @@ jobs:
   required_integration_tests:
     name: Required Integration Tests
     needs: build_docker_image
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.config.runner }}
     strategy:
       fail-fast: false
       matrix:
+        config:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
         tests:
           - test_backward_compatible
           - test_genesis_ceremony
@@ -441,14 +451,14 @@ jobs:
       - name: Load Docker Image
         uses: actions/download-artifact@v5
         with:
-          name: artifacts-docker-amd64
+          name: artifacts-docker-${{ matrix.config.arch }}
           path: /tmp
 
       - name: Import Docker Image
         shell: bash -ex {0}
         run: |
           zcat /tmp/rnode-docker.tar.gz | docker image load
-          docker tag f1r3flyindustries/f1r3fly-scala-node:amd64 f1r3flyindustries/f1r3fly-scala-node
+          docker tag f1r3flyindustries/f1r3fly-scala-node:${{ matrix.config.arch }} f1r3flyindustries/f1r3fly-scala-node
 
       - name: Run Integration Test
         shell: bash -ex {0}

--- a/.github/workflows/required-workflow.yml
+++ b/.github/workflows/required-workflow.yml
@@ -220,7 +220,18 @@ jobs:
   build_docker_image:
     name: Build Docker Image
     needs: build_base
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: [ubuntu-latest, ARM64]
+            arch: arm64
+    env:
+      PLATFORM: ${{ matrix.platform }}
     steps:
       - name: Clone Repository
         uses: actions/checkout@v5
@@ -274,20 +285,24 @@ jobs:
         shell: bash -ex {0}
         run: |
           docker context use default
-          MULTI_ARCH=true sbt ";compile ;project node ;Docker/publishLocal ;project rchain"
+          sbt ";compile ;project node ;Docker/publishLocal ;project rchain"
+
+      - name: Tag Docker Image with Arch
+        shell: bash -ex {0}
+        run: docker tag f1r3flyindustries/f1r3fly-scala-node f1r3flyindustries/f1r3fly-scala-node:${{ matrix.arch }}
 
       - name: Export Docker Image
         shell: bash -ex {0}
         run: |
           mkdir ../artifacts
           git describe --tags --always >../artifacts/version.txt
-          docker image save f1r3flyindustries/f1r3fly-scala-node \
+          docker image save f1r3flyindustries/f1r3fly-scala-node:${{ matrix.arch }} \
               | gzip > /tmp/rnode-docker.tar.gz
 
       - name: Save Docker Image
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts-docker
+          name: artifacts-docker-${{ matrix.arch }}
           path: /tmp/rnode-docker.tar.gz
 
   # Get compiled RChain, build distro packages, and save them for next jobs.
@@ -426,12 +441,14 @@ jobs:
       - name: Load Docker Image
         uses: actions/download-artifact@v5
         with:
-          name: artifacts-docker
+          name: artifacts-docker-amd64
           path: /tmp
 
       - name: Import Docker Image
         shell: bash -ex {0}
-        run: zcat /tmp/rnode-docker.tar.gz | docker image load
+        run: |
+          zcat /tmp/rnode-docker.tar.gz | docker image load
+          docker tag f1r3flyindustries/f1r3fly-scala-node:amd64 f1r3flyindustries/f1r3fly-scala-node
 
       - name: Run Integration Test
         shell: bash -ex {0}
@@ -463,15 +480,25 @@ jobs:
       github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
-      - name: Load Docker Image
+      - name: Load AMD64 Docker Image
         uses: actions/download-artifact@v5
         with:
-          name: artifacts-docker
-          path: /tmp
+          name: artifacts-docker-amd64
+          path: /tmp/amd64
 
-      - name: Import Docker Image
+      - name: Import AMD64 Docker Image
         shell: bash -ex {0}
-        run: zcat /tmp/rnode-docker.tar.gz | docker image load
+        run: zcat /tmp/amd64/rnode-docker.tar.gz | docker image load
+
+      - name: Load ARM64 Docker Image
+        uses: actions/download-artifact@v5
+        with:
+          name: artifacts-docker-arm64
+          path: /tmp/arm64
+
+      - name: Import ARM64 Docker Image
+        shell: bash -ex {0}
+        run: zcat /tmp/arm64/rnode-docker.tar.gz | docker image load
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -481,17 +508,19 @@ jobs:
 
       - name: Publish Docker Image
         env:
-          SOURCE_DOCKER_IMAGE_NAME: f1r3flyindustries/f1r3fly-scala-node
-          TARGET_DOCKER_IMAGE_NAME: ${{ secrets.LEGACY_DOCKER_IMAGE_NAME }}
           VERSION: ${{ needs.build_base.outputs.VERSION }}
           BRANCH: ${{ needs.build_base.outputs.BRANCH }}
           DEV_LATEST_TAG: ${{ needs.build_base.outputs.DEV_LATEST_TAG }}
         shell: bash -exu -o pipefail {0}
         run: |
-          if [[ -z "$TARGET_DOCKER_IMAGE_NAME" ]]; then
+          if [[ -z "${{ secrets.LEGACY_DOCKER_IMAGE_NAME }}" ]]; then
             echo "Required variable \$TARGET_DOCKER_IMAGE_NAME is not set." >&2
             exit 1
           fi
+
+          TARGET_DOCKER_IMAGE_NAME=${{ secrets.LEGACY_DOCKER_IMAGE_NAME }}
+          SOURCE_DOCKER_IMAGE_NAME_AMD64=f1r3flyindustries/f1r3fly-scala-node:amd64
+          SOURCE_DOCKER_IMAGE_NAME_ARM64=f1r3flyindustries/f1r3fly-scala-node:arm64
 
           SUFFIX=""
           CI_RUN=""
@@ -510,10 +539,23 @@ jobs:
           IMG_VERSION="${IMG_VERSION_RAW//[+]/__}"
           IMG_LATEST="$IMAGE_NAME:latest"
 
-          docker tag $SOURCE_DOCKER_IMAGE_NAME $IMG_VERSION
-          docker tag $SOURCE_DOCKER_IMAGE_NAME $IMG_LATEST
-          docker push $IMG_VERSION
-          docker push $IMG_LATEST
+          # Tag and push arch-specific images
+          docker tag $SOURCE_DOCKER_IMAGE_NAME_AMD64 $IMG_VERSION-amd64
+          docker tag $SOURCE_DOCKER_IMAGE_NAME_ARM64 $IMG_VERSION-arm64
+          docker push $IMG_VERSION-amd64
+          docker push $IMG_VERSION-arm64
+
+          docker tag $SOURCE_DOCKER_IMAGE_NAME_AMD64 $IMG_LATEST-amd64
+          docker tag $SOURCE_DOCKER_IMAGE_NAME_ARM64 $IMG_LATEST-arm64
+          docker push $IMG_LATEST-amd64
+          docker push $IMG_LATEST-arm64
+
+          # Create and push manifests
+          docker manifest create $IMG_VERSION --amend $IMG_VERSION-amd64 $IMG_VERSION-arm64
+          docker manifest push $IMG_VERSION
+
+          docker manifest create $IMG_LATEST --amend $IMG_LATEST-amd64 $IMG_LATEST-arm64
+          docker manifest push $IMG_LATEST
 
   # GitHub (create) release and packages
   release_packages:

--- a/.github/workflows/required-workflow.yml
+++ b/.github/workflows/required-workflow.yml
@@ -154,8 +154,6 @@ jobs:
         config:
           - runner: ubuntu-22.04
             arch: amd64
-          - runner: ubuntu-22.04-arm
-            arch: arm64
         # This runs unit tests in parallel.
         #
         # For each entry a runner node is spawned with entry value in
@@ -400,8 +398,6 @@ jobs:
         config:
           - runner: ubuntu-22.04
             arch: amd64
-          - runner: ubuntu-22.04-arm
-            arch: arm64
         tests:
           - test_backward_compatible
           - test_genesis_ceremony

--- a/.github/workflows/required-workflow.yml
+++ b/.github/workflows/required-workflow.yml
@@ -228,7 +228,7 @@ jobs:
             runner: ubuntu-latest
             arch: amd64
           - platform: linux/arm64
-            runner: [ubuntu-latest, ARM64]
+            runner: ubuntu-24.04-arm
             arch: arm64
     env:
       PLATFORM: ${{ matrix.platform }}

--- a/.github/workflows/required-workflow.yml
+++ b/.github/workflows/required-workflow.yml
@@ -26,7 +26,7 @@ jobs:
   # Build and save artifacts for next jobs.
   build_base:
     name: Build Base
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       VERSION: ${{ env.VERSION }}
       BRANCH: ${{ env.BRANCH }}
@@ -152,9 +152,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - runner: ubuntu-latest
+          - runner: ubuntu-22.04
             arch: amd64
-          - runner: ubuntu-24.04-arm
+          - runner: ubuntu-22.04-arm
             arch: arm64
         # This runs unit tests in parallel.
         #
@@ -230,10 +230,10 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
             arch: amd64
           - platform: linux/arm64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-22.04-arm
             arch: arm64
     env:
       PLATFORM: ${{ matrix.platform }}
@@ -315,7 +315,7 @@ jobs:
     name: Build Packages
     needs: build_base
     if: "github.event_name != 'pull_request'"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone Repository
         uses: actions/checkout@v5
@@ -398,9 +398,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - runner: ubuntu-latest
+          - runner: ubuntu-22.04
             arch: amd64
-          - runner: ubuntu-24.04-arm
+          - runner: ubuntu-22.04-arm
             arch: arm64
         tests:
           - test_backward_compatible
@@ -488,7 +488,7 @@ jobs:
       github.ref == 'refs/heads/trying' ||
       github.ref == 'refs/heads/staging' ||
       github.ref == 'refs/heads/main')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Load AMD64 Docker Image
         uses: actions/download-artifact@v5
@@ -577,7 +577,7 @@ jobs:
       - required_integration_tests
       - build_packages
     if: "github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Load Packages
         uses: actions/download-artifact@v5

--- a/build.sbt
+++ b/build.sbt
@@ -364,19 +364,8 @@ lazy val node = (project in file("node"))
     daemonUser in Docker := "daemon",
     dockerExposedPorts := List(40400, 40401, 40402, 40403, 40404),
     dockerBuildOptions := {
-      val baseOptions = Seq("-t", "f1r3flyindustries/f1r3fly-scala-node:latest")
-      val multiplatformOptions = Seq(
-        "--builder",
-        "default",
-        "--platform",
-        "linux/amd64,linux/arm64"
-      )
-      
-      if (sys.env.get("MULTI_ARCH").contains("true")) {
-        multiplatformOptions ++ baseOptions
-      } else {
-        baseOptions
-      }
+      val platform = sys.env.getOrElse("PLATFORM", "linux/amd64")
+      Seq("--platform", platform, "-t", "f1r3flyindustries/f1r3fly-scala-node:latest")
     },
     dockerCommands := {
       // Retrieve the default Docker commands provided by sbt-native-packager


### PR DESCRIPTION
Changes:
- Builds `linux/amd64` and `linux/arm64` images in parallel
- Combines the two images into one `latest` image
- Runs the unit and integration tests against both the amd64 and arm64 images
- Some of the arm64 unit tests and all the arm64 integration tests fail so they have been moved to the optional workflow since they were not required before. The integration tests fail because the Python version needed to run them is unavailable on arm64 with the current method of installation.
- Migrates `DOCKERHUB_USERNAME`, `DOCKER_IMAGE_NAME`, and `LEGACY_DOCKER_IMAGE_NAME` from Github secrets to variables since they are not sensitive and including them improves debuggability in the logs.